### PR TITLE
Add server-side events.

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -8,6 +8,9 @@ import cors from 'cors';
 import dotenv from 'dotenv';
 import express from 'express';
 import flash from 'connect-flash';
+
+import { initSSE } from './utils/sse.js';
+
 import morgan from 'morgan';
 import passport from 'passport';
 import session from 'express-session';
@@ -64,6 +67,7 @@ passport.deserializeUser(User.deserializeUser());
 app.use(morgan('dev'));
 
 // routes
+app.use('/stream', initSSE);
 app.use('/journals/:journalId/entries', entry);
 app.use('/access', access);
 

--- a/backend/src/middleware/entry/analysis.js
+++ b/backend/src/middleware/entry/analysis.js
@@ -1,0 +1,11 @@
+export const createAnalysis = async (req, res, next) => {
+  const { newEntry } = req.body;
+
+  analyzeEntry(newEntry)
+    .then(analysisResult => {
+      notifyClient(newEntry._id, analysisResult);
+    })
+    .catch(err => {
+      notifyClient(newEntry._id, err);
+    });
+};

--- a/backend/src/routes/entry/entry.js
+++ b/backend/src/routes/entry/entry.js
@@ -5,6 +5,7 @@ import { Router } from 'express';
 import catchAsync from '../../utils/catchAsync.js';
 
 import { entryController as controller } from '../../controllers/index.js';
+import { createAnalysis } from '../../middleware/entry/analysis.js';
 import { isAuthenticated } from '../../middleware/access.js';
 
 // root path: /journals/:journalId/entries
@@ -18,7 +19,7 @@ router.use(isAuthenticated);
  */
 router.route('/')
   .get(catchAsync(controller.getAllEntries))
-  .post(validateEntry, catchAsync(controller.createEntry));
+  .post(validateEntry, catchAsync(controller.createEntry), catchAsync(createAnalysis));
 
 router.route('/:entryId')
   .get(catchAsync(controller.getAnEntry))

--- a/backend/src/utils/sse.js
+++ b/backend/src/utils/sse.js
@@ -1,0 +1,22 @@
+let clients = [];
+
+export const initSSE = (req, res) => {
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    Connection: 'keep-alive'
+  });
+
+  // Add this client to the clients array
+  const clientId = Date.now();
+  const newClient = {
+    id: clientId,
+    res
+  };
+  clients.push(newClient);
+
+  // Remove client from array when connection is closed
+  req.on('close', () => {
+    clients = clients.filter(client => client.id !== clientId);
+  });
+};


### PR DESCRIPTION
This PR adds server-side events. Server-side events make the code more modular and streamlines creation routes. An analysis and LLM chat responses generally take several seconds longer than posting content created by a user. This is due to the extra step the server must make to the external API providing the LLM resources.

Currently, on every POST requiring an LLM, e.g. entry creation/update, and chat creation/update, the controller couples the creation logic with an LLM response if the LLM is connected. This logic should be decoupled whereas a createEntry/createChat controller should only post a new entry or chat to the database regardless of whether or not an analyses or chat response is made and the server should simply respond with the entry/chat and post it to the react app with a loading visualizer telling the user the LLM response has been requested and to please wait.

Currently, the user makes an entry/chat post, the textfields/buttons are disabled with a loading visualizer, and only when a response is made or fails is the users post posted. It's more natural to post it first, then await a response, simialr to how text messages work—you can see your post even if the other user didn't respond yet. The LLM should be treated like a separate user, but its being coupled with the user model in some sense.

The route on which these creation controllers are used should then call `next()` to use a separate getAnalyses/getChat middleware. Since the creation route is sending a response, and closing the socket, due to how HTTP request/response protocols work, another communication channel, either web socket or SSE, should be established. Since the user is only ever making one request, a web socket is unnecessary, making a server-side event ideal for this situation, as it allows only the server to push messages to the client without requiring a response.

The initial commits of this PR include creating an sse util (probably worth moving to middleware directory) to track connected clients to send server-side events to, creating an initial createAnalysis middleware to create analysis (needs to be implemented fully using the EntryAnalysis model method `getAnalysisContent`), adding the new SSE utility middleware to app, and adding the `createAnalysis` middleware to entries POST route.