### PR TITLE
refactor: organize interfaces into root level interfaces directory and improve test robustness

### DIFF
--- a/backend/src/assistants/Assistant.ts
+++ b/backend/src/assistants/Assistant.ts
@@ -1,32 +1,4 @@
-export interface Permission {
-  id: string;
-  object: string;
-  created: number;
-  allow_create_engine: boolean;
-  allow_sampling: boolean;
-  allow_logprobs: boolean;
-  allow_search_indices: boolean;
-  allow_view: boolean;
-  allow_fine_tuning: boolean;
-  organization: string;
-  group?: string | null;
-  is_blocking: boolean;
-}
-
-export interface Model {
-  id: string;
-  object: string;
-  created: number;
-  owned_by: string;
-  permission: Permission[];
-  root: string;
-  parent?: string | null;
-}
-
-export interface ModelsResponse {
-  object: string;
-  data: Model[];
-}
+import { Model, ModelsResponse } from '../interfaces/assistants/Model.js';
 
 export default class Assistant {
   baseUrl: string;

--- a/backend/src/assistants/gpts/CdGpt.ts
+++ b/backend/src/assistants/gpts/CdGpt.ts
@@ -1,4 +1,6 @@
+import { ChatCompletionResponse, ChatMessage, Message, Prompt } from '../../interfaces/entry/EntryConversation.js';
 import Assistant from '../Assistant.js';
+import { EntryAnalysis } from '../../interfaces/entry/EntryAnalysis.js';
 
 const analysisSeed: string = `
 ROLE
@@ -42,51 +44,6 @@ const formatInstructions: FormatInstructions = {
   mood: 'Inferred Mood from Thought',
   tags: ['Array', 'of', 'Relevant', 'Tags'],
 };
-
-export interface Message {
-  role: 'system' | 'user' | 'assistant';
-  content: string;
-}
-
-export interface Entry {
-  content: string;
-}
-
-export interface EntryAnalysis {
-  entry: Entry;
-  analysis_content: string;
-}
-
-export interface ChatMessage {
-  message_content: string;
-  llm_response: string;
-}
-
-export interface Prompt {
-  analysis?: string;
-  chat?: string;
-}
-
-export interface ChatCompletionChoice {
-  index: number;
-  message: Message;
-  finish_reason: string;
-}
-
-export interface ChatCompletionUsage {
-  prompt_tokens: number;
-  completion_tokens: number;
-  total_tokens: number;
-}
-
-export interface ChatCompletionResponse {
-  id: string;
-  object: string;
-  created: number;
-  model: string;
-  choices: ChatCompletionChoice[];
-  usage: ChatCompletionUsage;
-}
 
 /**
  * CDGPT Chat Assistant

--- a/backend/src/interfaces/assistants/Model.ts
+++ b/backend/src/interfaces/assistants/Model.ts
@@ -1,0 +1,16 @@
+import { Permission } from './Permission.js';
+
+export interface Model {
+  id: string;
+  object: string;
+  created: number;
+  owned_by: string;
+  permission: Permission[];
+  root: string;
+  parent?: string | null;
+}
+
+export interface ModelsResponse {
+  object: string;
+  data: Model[];
+}

--- a/backend/src/interfaces/assistants/Permission.ts
+++ b/backend/src/interfaces/assistants/Permission.ts
@@ -1,0 +1,14 @@
+export interface Permission {
+    id: string;
+    object: string;
+    created: number;
+    allow_create_engine: boolean;
+    allow_sampling: boolean;
+    allow_logprobs: boolean;
+    allow_search_indices: boolean;
+    allow_view: boolean;
+    allow_fine_tuning: boolean;
+    organization: string;
+    group?: string | null;
+    is_blocking: boolean;
+}

--- a/backend/src/interfaces/entry/Entry.ts
+++ b/backend/src/interfaces/entry/Entry.ts
@@ -1,0 +1,3 @@
+export interface Entry {
+    content: string;
+}

--- a/backend/src/interfaces/entry/EntryAnalysis.ts
+++ b/backend/src/interfaces/entry/EntryAnalysis.ts
@@ -1,0 +1,6 @@
+import { Entry } from './Entry.js';
+
+export interface EntryAnalysis {
+    entry: Entry;
+    analysis_content: string;
+}

--- a/backend/src/interfaces/entry/EntryConversation.ts
+++ b/backend/src/interfaces/entry/EntryConversation.ts
@@ -1,0 +1,35 @@
+export interface Message {
+    role: 'system' | 'user' | 'assistant';
+    content: string;
+}
+  
+export interface ChatMessage {
+    message_content: string;
+    llm_response: string;
+}
+  
+export interface Prompt {
+    analysis?: string;
+    chat?: string;
+}
+  
+export interface ChatCompletionChoice {
+    index: number;
+    message: Message;
+    finish_reason: string;
+}
+  
+export interface ChatCompletionUsage {
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_tokens: number;
+}
+  
+export interface ChatCompletionResponse {
+    id: string;
+    object: string;
+    created: number;
+    model: string;
+    choices: ChatCompletionChoice[];
+    usage: ChatCompletionUsage;
+}

--- a/backend/tests/assistants/Assistants.test.ts
+++ b/backend/tests/assistants/Assistants.test.ts
@@ -1,4 +1,4 @@
-import { Model, ModelsResponse } from '../../src/assistants/Assistant.js';
+import { Model, ModelsResponse } from '../../src/interfaces/assistants/Model.js';
 import Assistant from '../../src/assistants/Assistant.js';
 
 describe('Assistant Class', () => {
@@ -89,8 +89,12 @@ describe('Assistant Class', () => {
     it('should return the filtered model when it exists', () => {
       const assistant = new Assistant(bearerToken, 'MODEL2');
       const result = assistant.testModelAvailability(models);
-
-      expect(result).toEqual([models[1]]);
+    
+      const expectedModel = models.find(
+        (model) => model.id.toLowerCase() === 'model2'.toLowerCase()
+      );
+    
+      expect(result).toEqual(expectedModel ? [expectedModel] : models);
     });
 
     it('should return all models when the specified model does not exist', () => {


### PR DESCRIPTION
This PR addresses the reviews left by @davidzlu in PR #163. The following updates have been made:

- Refactored Assistants
  - Moved interfaces (`Permission`, `Model`, `ModelsResponse`, `Entry`, `EntryAnalysis`, `Message`, `ChatMessage`, `Prompt`, `ChatCompletionChoice`, `ChatCompletionUsage`, `ChatCompletionResponse`) into a new `interfaces` directory.
  - Updated import statements across modules to reference the new interface files.
  - Created separate files for each interface to promote reusability and maintainability.

- Improved Assistants test `should return the filtered model when it exists`
  - Updated test to avoid reliance on array indices in tests.
  - Modified the test to search for the expected model based on properties, making it more robust against changes in the models array.