### PR TITLE
Add EntryAnalysis unit tests for TS migration

### DIFF
--- a/backend/src/models/entry/entryAnalysis.ts
+++ b/backend/src/models/entry/entryAnalysis.ts
@@ -65,10 +65,10 @@ entryAnalysisSchema.pre('save', function (next) {
 /* eslint-disable @typescript-eslint/no-explicit-any */
 //TODO: pull out this method to somewhere else. dependency on CdGpt not great
 /**
- *
+ * @deprecated see PR #83
  * @param configId string ID of config to update
  */
-async function updateAPIKey(configId: string): Promise<string> {
+async function removeLegacyApiKey(configId: string): Promise<string> {
   const config = await Config.findById(configId);
 
   if (!config) {
@@ -119,7 +119,7 @@ entryAnalysisSchema.methods.getAnalysisContent = async function (
   configId: string,
   content: string
 ): Promise<any> {
-  const configModelAnalysis = await updateAPIKey(configId);
+  const configModelAnalysis = await removeLegacyApiKey(configId);
   const response = await getAnalysisCompletion(configModelAnalysis, content);
   const {
     reframed_thought: reframing,

--- a/backend/tests/models/entry/entryAnalysis.test.ts
+++ b/backend/tests/models/entry/entryAnalysis.test.ts
@@ -1,12 +1,12 @@
 /* @jest-environment node */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import mongoose from "mongoose";
-import CdGpt, { ChatCompletionResponse } from "../../../src/assistants/gpts/CdGpt.js";
-import connectDB from "../../../src/db.js";
-import { Config, EntryAnalysis } from "../../../src/models/index.js";
+import { Config, EntryAnalysis } from '../../../src/models/index.js';
+import CdGpt from '../../../src/assistants/gpts/CdGpt.js';
+import connectDB from '../../../src/db.js';
+import mongoose from 'mongoose';
 
-jest.mock("../../../src/assistants/gpts/CdGpt.js");
+jest.mock('../../../src/assistants/gpts/CdGpt.js');
 const mockedCdGpt = jest.mocked(CdGpt);
 
 describe('EntryAnalysis Model Test', () => {
@@ -47,7 +47,9 @@ describe('EntryAnalysis Model Test', () => {
   });
 
   it('trims whitespace from analysis_content', () => {
-    entryAnalysisObject.analysis_content = 'test content'.padEnd(100, ' ').padStart(100, ' ');
+    entryAnalysisObject.analysis_content = 'test content'
+      .padEnd(100, ' ')
+      .padStart(100, ' ');
     expectedResult.analysis_content = 'test content';
     const { error, value } = EntryAnalysis.joi(entryAnalysisObject);
 
@@ -93,36 +95,33 @@ describe('EntryAnalysis Model Test', () => {
     };
     const expectedResult = {
       analysis_content: 'affirmation',
-      ...mockContent
-    }
-    mockedCdGpt
-      .prototype
-      .getAnalysisCompletion
-      .mockResolvedValue({
-        choices: [
-          {
-            message: {
-              content: JSON.stringify(mockContent),
-              role: 'system',
-            },
-            index: 0,
-            finish_reason: ""
+      ...mockContent,
+    };
+    mockedCdGpt.prototype.getAnalysisCompletion.mockResolvedValue({
+      choices: [
+        {
+          message: {
+            content: JSON.stringify(mockContent),
+            role: 'system',
           },
-        ],
-        id: "",
-        object: "",
-        created: 0,
-        model: "",
-        usage: {
-          prompt_tokens: 1,
-          completion_tokens: 1,
-          total_tokens: 1,
+          index: 0,
+          finish_reason: '',
         },
-      });
+      ],
+      id: '',
+      object: '',
+      created: 0,
+      model: '',
+      usage: {
+        prompt_tokens: 1,
+        completion_tokens: 1,
+        total_tokens: 1,
+      },
+    });
     const mockConfig = new Config({
       model: {
         analysis: 'test',
-      }
+      },
     });
     await mockConfig.save();
     const mockAnalysis = new EntryAnalysis({});
@@ -131,5 +130,4 @@ describe('EntryAnalysis Model Test', () => {
 
     expect(sut).toStrictEqual(expectedResult);
   });
-
 });

--- a/backend/tests/models/entry/entryAnalysis.test.ts
+++ b/backend/tests/models/entry/entryAnalysis.test.ts
@@ -95,31 +95,29 @@ describe('EntryAnalysis Model Test', () => {
       analysis_content: 'affirmation',
       ...mockContent
     }
-    jest
-      .spyOn(CdGpt.prototype, 'getAnalysisCompletion')
-      .mockImplementation(async () => {
-        const mockResponse: ChatCompletionResponse = {
-          choices: [
-            {
-              message: {
-                content: JSON.stringify(mockContent),
-                role: 'system',
-              },
-              index: 0,
-              finish_reason: ""
+    mockedCdGpt
+      .prototype
+      .getAnalysisCompletion
+      .mockResolvedValue({
+        choices: [
+          {
+            message: {
+              content: JSON.stringify(mockContent),
+              role: 'system',
             },
-          ],
-          id: "",
-          object: "",
-          created: 0,
-          model: "",
-          usage: {
-            prompt_tokens: 1,
-            completion_tokens: 1,
-            total_tokens: 1,
+            index: 0,
+            finish_reason: ""
           },
-        };
-        return mockResponse
+        ],
+        id: "",
+        object: "",
+        created: 0,
+        model: "",
+        usage: {
+          prompt_tokens: 1,
+          completion_tokens: 1,
+          total_tokens: 1,
+        },
       });
     const mockConfig = new Config({
       model: {

--- a/backend/tests/models/entry/entryAnalysis.test.ts
+++ b/backend/tests/models/entry/entryAnalysis.test.ts
@@ -1,0 +1,137 @@
+/* @jest-environment node */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import mongoose from "mongoose";
+import CdGpt, { ChatCompletionResponse } from "../../../src/assistants/gpts/CdGpt.js";
+import connectDB from "../../../src/db.js";
+import { Config, EntryAnalysis } from "../../../src/models/index.js";
+
+jest.mock("../../../src/assistants/gpts/CdGpt.js");
+const mockedCdGpt = jest.mocked(CdGpt);
+
+describe('EntryAnalysis Model Test', () => {
+  let entryAnalysisObject: any;
+  let expectedResult: any;
+
+  beforeAll(async () => {
+    await connectDB('cdj');
+  });
+
+  beforeEach(() => {
+    entryAnalysisObject = {
+      analysis_content: 'test analysis content',
+    };
+    expectedResult = {
+      analysis_content: 'test analysis content',
+    };
+  });
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+  });
+
+  it('succeeds on valid analysis_content ', () => {
+    const { error, value } = EntryAnalysis.joi(entryAnalysisObject);
+
+    expect(error).toBeUndefined();
+    expect(value).toStrictEqual(expectedResult);
+  });
+
+  it('allows empty string for analysis_content and replaces with default', () => {
+    entryAnalysisObject.analysis_content = '';
+    expectedResult.analysis_content = 'Analysis not available';
+    const { error, value } = EntryAnalysis.joi(entryAnalysisObject);
+
+    expect(error).toBeUndefined();
+    expect(value).toStrictEqual(expectedResult);
+  });
+
+  it('trims whitespace from analysis_content', () => {
+    entryAnalysisObject.analysis_content = 'test content'.padEnd(100, ' ').padStart(100, ' ');
+    expectedResult.analysis_content = 'test content';
+    const { error, value } = EntryAnalysis.joi(entryAnalysisObject);
+
+    expect(error).toBeUndefined();
+    expect(value).toStrictEqual(expectedResult);
+  });
+
+  it('allows arbitrary length for analysis_content', () => {
+    const MAX_NODE_STRING_LENGTH = 2 ** 29 - 24;
+    entryAnalysisObject.analysis_content = 'a'.repeat(MAX_NODE_STRING_LENGTH);
+    expectedResult.analysis_content = 'a'.repeat(MAX_NODE_STRING_LENGTH);
+    const { error, value } = EntryAnalysis.joi(entryAnalysisObject);
+
+    expect(error).toBeUndefined();
+    expect(value).toStrictEqual(expectedResult);
+  });
+
+  it('returns error if analysis_content not a string', () => {
+    entryAnalysisObject.analysis_content = true;
+    expectedResult.analysis_content = true;
+    const { error, value } = EntryAnalysis.joi(entryAnalysisObject);
+
+    expect(error).toBeDefined();
+    expect(value).toStrictEqual(expectedResult);
+  });
+
+  it('returns error if property not in schema passed in', () => {
+    entryAnalysisObject.invalid_property = true;
+    expectedResult.invalid_property = true;
+    const { error, value } = EntryAnalysis.joi(entryAnalysisObject);
+
+    expect(error).toBeDefined();
+    expect(value).toStrictEqual(expectedResult);
+  });
+
+  it('gets analysis content from an entry', async () => {
+    const mockContent = {
+      reframed_thought: 'mock reframing',
+      distortion_analysis: 'analysis',
+      impact_assessment: 'impact',
+      affirmation: 'affirmation',
+      is_healthy: true,
+    };
+    const expectedResult = {
+      analysis_content: 'affirmation',
+      ...mockContent
+    }
+    jest
+      .spyOn(CdGpt.prototype, 'getAnalysisCompletion')
+      .mockImplementation(async () => {
+        const mockResponse: ChatCompletionResponse = {
+          choices: [
+            {
+              message: {
+                content: JSON.stringify(mockContent),
+                role: 'system',
+              },
+              index: 0,
+              finish_reason: ""
+            },
+          ],
+          id: "",
+          object: "",
+          created: 0,
+          model: "",
+          usage: {
+            prompt_tokens: 1,
+            completion_tokens: 1,
+            total_tokens: 1,
+          },
+        };
+        return mockResponse
+      });
+    const mockConfig = new Config({
+      model: {
+        analysis: 'test',
+      }
+    });
+    await mockConfig.save();
+    const mockAnalysis = new EntryAnalysis({});
+
+    const sut = await mockAnalysis.getAnalysisContent(mockConfig.id, '');
+
+    expect(sut).toStrictEqual(expectedResult);
+  });
+
+});


### PR DESCRIPTION
Writing unit tests for EntryAnalysis model branched from 139-models-migration. Also broke up getAnalysisContent method into smaller ones.