### PR TITLE
Add entryconversation unit tests for models migration

### DIFF
--- a/backend/src/models/entry/entryConversation.ts
+++ b/backend/src/models/entry/entryConversation.ts
@@ -9,7 +9,7 @@ import Joi from 'joi';
 
 export interface EntryConversationType {
   entry: Types.ObjectId,
-  messages: [{
+  messages?: [{
     message_content: string,
     llm_response?: string,
     created_at?: Date,

--- a/backend/tests/models/entry/entryConversation.test.ts
+++ b/backend/tests/models/entry/entryConversation.test.ts
@@ -1,0 +1,8 @@
+/**
+ * @jest-environment node
+ */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+describe('EntryConversation tests', () => {
+  
+});

--- a/backend/tests/models/entry/entryConversation.test.ts
+++ b/backend/tests/models/entry/entryConversation.test.ts
@@ -3,6 +3,189 @@
  */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import { EntryConversation } from "../../../src/models/index.js";
+
 describe('EntryConversation tests', () => {
-  
+  let entryConversationObject: any;
+  let expectedResult: any;
+
+  beforeEach(() => {
+    entryConversationObject = {
+      messages: [
+        {
+          message_content: 'test message 1',
+          llm_response: 'test response 1',
+          created_at: new Date(0),
+        },
+        {
+          message_content: 'test message 2',
+          llm_response: 'test response 2',
+          created_at: new Date(0),
+        }
+      ]
+    };
+    expectedResult = {
+      messages: [
+        {
+          message_content: 'test message 1',
+          llm_response: 'test response 1',
+          created_at: new Date(0),
+        },
+        {
+          message_content: 'test message 2',
+          llm_response: 'test response 2',
+          created_at: new Date(0),
+        }
+      ]
+    };
+  });
+
+  it('succeeds with valid input for EntryConversation', () => {
+    const { error, value } = EntryConversation.joi(entryConversationObject);
+
+    expect(error).toBeUndefined();
+    expect(value).toStrictEqual(expectedResult);
+  });
+
+  it('does not require messages to be present', () => {
+    entryConversationObject = {};
+    expectedResult = {};
+    const { error, value } = EntryConversation.joi(entryConversationObject);
+
+    expect(error).toBeUndefined();
+    expect(value).toStrictEqual(expectedResult);
+  });
+
+  it('allows messages to be empty list', () => {
+    entryConversationObject.messages = [];
+    expectedResult.messages = [];
+    
+    const { error, value } = EntryConversation.joi(entryConversationObject);
+
+    expect(error).toBeUndefined();
+    expect(value).toStrictEqual(expectedResult);
+  });
+
+  it('returns error if message in messages has undefined message_content', () => {
+    entryConversationObject.messages = [{}];
+    expectedResult.messages = [{}];
+
+    const { error, value } = EntryConversation.joi(entryConversationObject);
+
+    expect(error).toBeDefined();
+    expect(value).toStrictEqual(expectedResult);
+  });
+
+  it('returns error if message_content an empty string', () => {
+    entryConversationObject.messages = [{ message_content: '' }];
+    expectedResult.messages = [{ message_content: '' }];
+
+    const { error, value } = EntryConversation.joi(entryConversationObject);
+
+    expect(error).toBeDefined();
+    expect(value).toStrictEqual(expectedResult);
+  });
+
+  it('trims whitespace in message_content', () => {
+    entryConversationObject.messages = [
+      {
+        message_content: '  test trim  ',
+        llm_response: 'testresponse'
+      }
+    ];
+    expectedResult.messages = [
+      {
+        message_content: 'test trim',
+        llm_response: 'testresponse'
+      }
+    ];
+
+    const { error, value } = EntryConversation.joi(entryConversationObject);
+
+    expect(error).toBeUndefined();
+    expect(value).toStrictEqual(expectedResult);
+  });
+
+  it('sets default llm_response if empty', () => {
+    entryConversationObject.messages = [
+      {
+        message_content: 'test content',
+      }
+    ];
+    expectedResult.messages = [
+      {
+        message_content: 'test content',
+        llm_response: 'Not connected to LLM',
+      }
+    ];
+
+    const { error, value } = EntryConversation.joi(entryConversationObject);
+
+    expect(error).toBeUndefined();
+    expect(value).toStrictEqual(expectedResult);
+  });
+
+  it('trims whitespace in llm_response', () => {
+    entryConversationObject.messages = [
+      {
+        message_content: 'test content',
+        llm_response: '     test trim    '
+      }
+    ];
+    expectedResult.messages = [
+      {
+        message_content: 'test content',
+        llm_response: 'test trim'
+      }
+    ];
+
+    const { error, value } = EntryConversation.joi(entryConversationObject);
+
+    expect(error).toBeUndefined();
+    expect(value).toStrictEqual(expectedResult);
+  });
+
+  it('returns error if created_at not a date', () => {
+    entryConversationObject.messages = [
+      {
+        message_content: 'test message 1',
+        llm_response: 'test response 1',
+        created_at: 'not date',
+      },
+    ];
+    expectedResult.messages = [
+      {
+        message_content: 'test message 1',
+        llm_response: 'test response 1',
+        created_at: 'not date',
+      },
+    ];
+
+    const { error, value } = EntryConversation.joi(entryConversationObject);
+
+    expect(error).toBeDefined();
+    expect(value).toStrictEqual(expectedResult);
+  });
+
+  it('succeeds validation with date string and converts to Date type', () => {
+    entryConversationObject.messages = [
+      {
+        message_content: 'test message 1',
+        llm_response: 'test response 1',
+        created_at: new Date(0).toString(),
+      },
+    ];
+    expectedResult.messages = [
+      {
+        message_content: 'test message 1',
+        llm_response: 'test response 1',
+        created_at: new Date(0),
+      },
+    ];
+
+    const { error, value } = EntryConversation.joi(entryConversationObject);
+
+    expect(error).toBeUndefined();
+    expect(value).toStrictEqual(expectedResult);
+  });
 });


### PR DESCRIPTION
Add unit tests for EntryConversation as part of models migration to typescript.