### PR TITLE
refactor: create entry services refactoring

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -86,7 +86,6 @@ app.use(passport.authenticate('session'));
 
 // Passport config
 passport.use(User.createStrategy());
-// @ts-expect-error  Error from mismatch between User model and Express.User types. Implemented same way as passport-local-mongoose docs suggest
 passport.serializeUser(User.serializeUser());
 passport.deserializeUser(User.deserializeUser());
 

--- a/backend/src/controllers/access/access.ts
+++ b/backend/src/controllers/access/access.ts
@@ -9,7 +9,6 @@ import {
 import { NextFunction, Request, Response } from 'express';
 import jwt, { JwtPayload } from 'jsonwebtoken';
 import ExpressError from '../../utils/ExpressError.js';
-import { HydratedDocument } from 'mongoose';
 import { UserType } from '../../models/user.js';
 import crypto from 'crypto';
 import passport from 'passport';
@@ -248,7 +247,7 @@ export const login = async (req: Request, res: Response, next: NextFunction) => 
   type AuthenticateInfo = {
     message: string;
   };
-  passport.authenticate('local', async (err: Error, user: HydratedDocument<UserType> | null, info: AuthenticateInfo) => {
+  passport.authenticate('local', async (err: Error, user: UserType | null, info: AuthenticateInfo) => {
     if (err) {
       return next(err);
     }

--- a/backend/src/controllers/entry/entry.ts
+++ b/backend/src/controllers/entry/entry.ts
@@ -13,7 +13,10 @@ import ExpressError from '../../utils/ExpressError.js';
 /**
  * Get all entries in a specific journal.
  */
-export const getAllEntries = async (req: Request, res: Response) => {
+export const getAllEntries = async (
+  req: Request,
+  res: Response
+) => {
   const { journalId } = req.params;
 
   const entries = await EntryServices.getAllEntriesInJournal(journalId);
@@ -29,7 +32,11 @@ export const getAllEntries = async (req: Request, res: Response) => {
  * Request params journalId: string
  * Request body matches joiEntrySchema, but might be missing fields
  */
-export const createEntry = async (req: Request, res: Response, next: NextFunction) => {
+export const createEntry = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   const { journalId } = req.params;
   const entryData = req.body;
 
@@ -42,23 +49,26 @@ export const createEntry = async (req: Request, res: Response, next: NextFunctio
     return next(new ExpressError('Journal config not found.', 404));
   }
 
-  try {
-    const newEntry = await EntryServices.createEntry(
-      journalId,
-      journal.config.toString(),
-      entryData
-    );
+  const { errMessage, entry: newEntry } = await EntryServices.createEntry(
+    journalId,
+    journal.config.toString(),
+    entryData
+  );
 
-    res.status(201).json({ ... newEntry.toObject(), flash: req.flash() });
-  } catch (analysisError) {
-    req.flash('info', (analysisError as Error).message);
+  if (errMessage) {
+    req.flash('info', errMessage);
   }
+  res.status(201).json({ ...newEntry.toObject(), flash: req.flash() });
 };
 
 /**
  * Get an entry and all associated documents by ID.
  */
-export const getAnEntry = async (req: Request, res: Response, next: NextFunction) => {
+export const getAnEntry = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   const { entryId } = req.params;
 
   try {
@@ -73,7 +83,11 @@ export const getAnEntry = async (req: Request, res: Response, next: NextFunction
 /**
  * Update an entry by ID.
  */
-export const updateEntry = async (req: Request, res: Response, next: NextFunction) => {
+export const updateEntry = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   const { entryId, journalId } = req.params;
   const entryData = req.body;
 
@@ -130,7 +144,11 @@ export const updateEntry = async (req: Request, res: Response, next: NextFunctio
 /**
  * Delete an entry by ID and all associated documents.
  */
-export const deleteEntry = async (req: Request, res: Response, next: NextFunction) => {
+export const deleteEntry = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   const { entryId } = req.params;
 
   // Start a session and transaction for atomicity
@@ -172,7 +190,11 @@ export const deleteEntry = async (req: Request, res: Response, next: NextFunctio
 /**
  * Get an entry and its analysis by ID.
  */
-export const getEntryAnalysis = async (req: Request, res: Response, next: NextFunction) => {
+export const getEntryAnalysis = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   const { entryId } = req.params;
 
   const entryAnalysis = await EntryServices.getPopluatedEntryAnalysis(entryId);
@@ -187,7 +209,11 @@ export const getEntryAnalysis = async (req: Request, res: Response, next: NextFu
 /**
  * Update the analysis of an entry by entry ID.
  */
-export const updateEntryAnalysis = async (req: Request, res: Response, next: NextFunction) => {
+export const updateEntryAnalysis = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   const { entryId, journalId } = req.params;
 
   // Ensure that the journal exists
@@ -233,7 +259,11 @@ export const updateEntryAnalysis = async (req: Request, res: Response, next: Nex
 
   res
     .status(200)
-    .json({ ...entryAnalysis.toObject(), entry: entry.toObject(), flash: req.flash() });
+    .json({
+      ...entryAnalysis.toObject(),
+      entry: entry.toObject(),
+      flash: req.flash(),
+    });
 };
 
 /**
@@ -253,7 +283,11 @@ export const getEntryConversation = async (req: Request, res: Response) => {
 /**
  * Create a conversation for a specific entry.
  */
-export const createEntryConversation = async (req: Request, res: Response, next: NextFunction) => {
+export const createEntryConversation = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   const { entryId, journalId } = req.params;
   const messageData = req.body;
 
@@ -272,7 +306,9 @@ export const createEntryConversation = async (req: Request, res: Response, next:
   }
 
   // Get an entry with the analysis
-  const entry = await Entry.findById(entryId).populate<{ analysis: Document<EntryAnalysisType> }>('analysis');
+  const entry = await Entry.findById(entryId).populate<{
+    analysis: Document<EntryAnalysisType>;
+  }>('analysis');
   if (!entry) {
     return next(new ExpressError('Entry not found.', 404));
   }
@@ -286,7 +322,7 @@ export const createEntryConversation = async (req: Request, res: Response, next:
 
   try {
     if (entry.analysis === undefined) {
-      return next(new ExpressError('Entry analysis not found.' , 500));
+      return next(new ExpressError('Entry analysis not found.', 500));
     }
     const llmResponse = await newConversation.getChatContent(
       journal.config.toString(),
@@ -317,7 +353,11 @@ export const createEntryConversation = async (req: Request, res: Response, next:
 /**
  * Update a conversation for a specific entry.
  */
-export const updateEntryConversation = async (req: Request, res: Response, next: NextFunction) => {
+export const updateEntryConversation = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   const { chatId, journalId } = req.params;
   const messageData = req.body;
 
@@ -333,7 +373,9 @@ export const updateEntryConversation = async (req: Request, res: Response, next:
     return next(new ExpressError('Entry conversation not found.', 404));
   }
   if (!conversation.messages) {
-    return next(new ExpressError('Entry conversation messages not found.', 404));
+    return next(
+      new ExpressError('Entry conversation messages not found.', 404)
+    );
   }
 
   // Get the analysis associated with the entry

--- a/backend/src/controllers/entry/entry.ts
+++ b/backend/src/controllers/entry/entry.ts
@@ -71,10 +71,7 @@ export const getAnEntry = async (req: Request, res: Response, next: NextFunction
   const { entryId } = req.params;
 
   try {
-    const entry = await Entry.findById(entryId).populate(
-      'analysis conversation'
-    );
-
+    const entry = EntryServices.getPopulatedEntry(entryId, 'analysis conversation');
     res.status(200).json(entry);
   } catch (err) {
     req.flash('info', (err as Error).message);

--- a/backend/src/models/entry/entryAnalysis.ts
+++ b/backend/src/models/entry/entryAnalysis.ts
@@ -52,7 +52,6 @@ entryAnalysisSchema.pre('save', function (next) {
 
 //TODO: pull out this method to somewhere else. dependency on CdGpt not great
 // Get the analysis content for an entry
-// TODO: References to config type in this method are breaking test suite for some reason. Just try removing from here. Maybe it's a race condition within Jest b/c it's not happening with EntryConversation?
 entryAnalysisSchema.methods.getAnalysisContent = async function (configId: string, content: string): Promise<any> {
   const config = await Config.findById(configId);
 

--- a/backend/src/models/entry/entryAnalysis.ts
+++ b/backend/src/models/entry/entryAnalysis.ts
@@ -14,7 +14,7 @@ export interface EntryAnalysisType {
 /* eslint-disable @typescript-eslint/no-explicit-any */
 // TODO: any should be replaced with return type from cdgpt response
 interface EntryAnalysisMethods {
-  // GetAnalysisContent(configId: string, content: string): Promise<any>,
+  getAnalysisContent(configId: string, content: string): Promise<any>,
 }
 
 /* eslint-disable @typescript-eslint/no-empty-object-type */

--- a/backend/src/models/entry/entryAnalysis.ts
+++ b/backend/src/models/entry/entryAnalysis.ts
@@ -14,7 +14,7 @@ export interface EntryAnalysisType {
 /* eslint-disable @typescript-eslint/no-explicit-any */
 // TODO: any should be replaced with return type from cdgpt response
 interface EntryAnalysisMethods {
-  getAnalysisContent(configId: string, content: string): Promise<any>,
+  // GetAnalysisContent(configId: string, content: string): Promise<any>,
 }
 
 /* eslint-disable @typescript-eslint/no-empty-object-type */
@@ -52,6 +52,7 @@ entryAnalysisSchema.pre('save', function (next) {
 
 //TODO: pull out this method to somewhere else. dependency on CdGpt not great
 // Get the analysis content for an entry
+// TODO: References to config type in this method are breaking test suite for some reason. Just try removing from here. Maybe it's a race condition within Jest b/c it's not happening with EntryConversation?
 entryAnalysisSchema.methods.getAnalysisContent = async function (configId: string, content: string): Promise<any> {
   const config = await Config.findById(configId);
 

--- a/backend/src/models/services/entry/entry.ts
+++ b/backend/src/models/services/entry/entry.ts
@@ -32,7 +32,7 @@ export async function getAllEntriesInJournal(
  * Gets Entry with all referenced properties populated
  * @param entryId string of Entry._id to get
  * @param paths string of properties to populate
- * @returns Populated entry document
+ * @returns Populated entry document matching entryId
  */
 export async function getPopulatedEntry(entryId: string) {
   return await Entry
@@ -45,8 +45,8 @@ export async function getPopulatedEntry(entryId: string) {
 
 /**
  * Gets EntryAnalysis corresponding to entryId and populates with its Entry
- * @param entryId 
- * @returns 
+ * @param entryId string of Entry._id to get
+ * @returns populated EntryAnalysis document matching entryId
  */
 export async function getPopluatedEntryAnalysis(entryId: string) {
   try {
@@ -63,8 +63,8 @@ export async function getPopluatedEntryAnalysis(entryId: string) {
 
 /**
  * Gets EntryConversation corresponding to entryId
- * @param entryId 
- * @returns 
+ * @param entryId string of Entry._id to get
+ * @returns EntryConversation matching entryId
  */
 export async function getEntryConversation(entryId: string) {
   try {

--- a/backend/src/models/services/entry/entry.ts
+++ b/backend/src/models/services/entry/entry.ts
@@ -53,7 +53,7 @@ export namespace EntryServices {
   }
 
   /**
-   * Creates new EntryAnalysis for an Entry, and updates entry with
+   * Creates empty EntryAnalysis for an Entry, and updates entry with
    * refernces to new EntryAnalysis.
    * @param configId Config._id as string
    * @param refEntry Document of target Entry to generate analysis for
@@ -137,7 +137,8 @@ export namespace EntryServices {
     cdGpt.seedAnalysisMessages();
     cdGpt.addUserMessage({ analysis: content });
 
-    const analysisCompletion = await cdGpt.getAnalysisCompletion();
+    //TODO: replace type with better fitting one
+    const analysisCompletion: any = await cdGpt.getAnalysisCompletion();
 
     if (analysisCompletion.error) {
       throw new Error(analysisCompletion.error.message);
@@ -157,4 +158,16 @@ export namespace EntryServices {
 
     return response;
   };
+
+  /**
+   * Gets Entry with populated properties
+   * @param entryId string of Entry._id to get
+   * @param paths string of properties to populate based on Mongoose API
+   * @returns Populated entry document
+   */
+  export async function getPopulatedEntry(entryId: string, paths: string) {
+    return await Entry
+      .findById(entryId)
+      .populate(paths);
+  }
 }

--- a/backend/src/models/services/entry/entry.ts
+++ b/backend/src/models/services/entry/entry.ts
@@ -1,0 +1,125 @@
+import { HydratedDocument } from 'mongoose';
+import { EntryType } from '../../entry/entry.js';
+import { EntryAnalysisType } from '../../entry/entryAnalysis.js';
+import {
+  Config,
+  Entry,
+  EntryAnalysis,
+  EntryConversation,
+  Journal,
+} from '../../index.js';
+import CdGpt from '../../../assistants/gpts/CdGpt.js';
+
+export namespace EntryServices {
+
+  /**
+   * 
+   * @param journalId 
+   * @returns 
+   */
+  export async function getAllEntries(journalId: string): Promise<HydratedDocument<EntryType>[]> {
+    return await Entry.find({ journal: journalId });
+  }
+
+  /**
+   * 
+   * @param journalId 
+   * @returns 
+   */
+  export async function canCreateEntry(journalId: string): Promise<boolean> {
+    const journal = await Journal.findById(journalId);
+    return journal ? true : false;
+  }
+
+  /**
+   * 
+   * @param journalId 
+   * @param entryData 
+   */
+  export async function createEntry(journalId: string, entryContent: object): Promise<HydratedDocument<EntryType>> {
+    const newEntry = new Entry({ journal: journalId, ...entryContent }); // entryContent has non-schema fields after validation middleware, but b/c strict mode, non-schema fields are dropped
+    await newEntry.save();
+    return newEntry;
+  }
+
+  /**
+   * 
+   * @param entryId 
+   * @param refEntry 
+   * @returns 
+   */
+  export async function createEntryAnalysis(configId: string, refEntry: HydratedDocument<EntryType>): Promise<HydratedDocument<EntryAnalysisType>> {
+    const newAnalysis = new EntryAnalysis({
+      entry: refEntry.id,
+    });
+
+    // Associate the entry with the analysis
+    refEntry.analysis = newAnalysis.id;
+
+    try { // TODO:  try to extract this out into separate method. Hard because typining from getAnalysisContent not defined right, and having it as a model method is making it really difficult to separate from this function
+      const analysis = await getAnalysisContent(
+        configId,
+        refEntry.content
+      );
+
+      // Complete the entry and analysis with the analysis content if available
+      if (analysis) { // DL 9-27-24: I don't think users can set these from the UI
+        refEntry.title = analysis.title;
+        refEntry.mood = analysis.mood;
+        refEntry.tags = analysis.tags;
+
+        newAnalysis.analysis_content = analysis.analysis_content;
+      }
+    } catch (analysisError) {
+      throw analysisError;
+    } finally {
+      await refEntry.save();
+      await newAnalysis.save();
+    }
+    return newAnalysis;
+  }
+
+  async function getAnalysisContent(configId: string, content: string): Promise<any> {
+    const config = await Config.findById(configId);
+
+    if (!config) {
+      throw new Error('Configure your account settings to get an analysis.');
+    } else if (config.apiKey) {
+      try {
+        // Remove an API key from a legacy config
+        await Config.findByIdAndUpdate(config._id, { $unset: { apiKey: 1 } });
+      } catch (err) {
+        if (typeof err === "string") {
+          throw new Error(err);
+        } else if (err instanceof Error) {
+          throw err;
+        }
+      }
+    }
+
+    const cdGpt = new CdGpt(process.env.OPENAI_API_KEY, config.model.analysis);
+
+    cdGpt.seedAnalysisMessages();
+    cdGpt.addUserMessage({ analysis: content });
+
+    const analysisCompletion = await cdGpt.getAnalysisCompletion();
+
+    if (analysisCompletion.error) {
+      throw new Error(analysisCompletion.error.message);
+    }
+
+    const response = JSON.parse(analysisCompletion.choices[0].message.content);
+
+    const { reframed_thought: reframing, distortion_analysis: analysis, impact_assessment: impact, affirmation, is_healthy: isHealthy } = response;
+
+    if (!isHealthy) {
+      if (!analysis || !impact || !reframing) {
+        throw new Error('Analysis content is not available.');
+      }
+
+      response.analysis_content = analysis + ' ' + impact + ' Think, "' + reframing + '"' || affirmation;
+    } else response.analysis_content = affirmation;
+
+    return response;
+  };
+}

--- a/backend/src/models/services/entry/entry.ts
+++ b/backend/src/models/services/entry/entry.ts
@@ -75,7 +75,7 @@ export async function getEntryConversation(entryId: string) {
   return null;
 }
 
-// TODO: All functions below are in-progress. DL will be working on them in other PRs
+// TODO: All functions below are in-progress for create operations and are not being used currently. DL will be working on them in other PRs
 
 /**
  * Creates a new entry in journalId with entryContent as content
@@ -136,7 +136,7 @@ export async function populateAnalysisContent(
   refAnalysis: HydratedDocument<EntryAnalysisType>
 ): Promise<void> {
   try {
-    const analysis = await refAnalysis.getAnalysisContent(
+    const analysis = await getAnalysisContent(
       configId,
       refEntry.content
     );

--- a/backend/src/models/services/entry/entry.ts
+++ b/backend/src/models/services/entry/entry.ts
@@ -179,7 +179,10 @@ export async function createEntryConversation(
     entry: entryId,
     ...messageData,
   });
-  // I don't think this case will ever get used because joi validation rejects empty messages, and that happens before hitting this function
+  /**
+   * I don't think this case will ever get used because joi validation
+   * rejects empty messages, and that happens before hitting this function, but it's defensive
+   */
   if (!newConversation.messages || newConversation.messages.length === 0) {
     throw new ExpressError('No message to get completion for.', 404);
   }

--- a/backend/src/models/services/entry/entry.ts
+++ b/backend/src/models/services/entry/entry.ts
@@ -6,8 +6,22 @@ import {
 import { EntryAnalysisType } from '../../entry/entryAnalysis.js';
 import { EntryConversationType } from '../../entry/entryConversation.js';
 import { EntryType } from '../../entry/entry.js';
+import ExpressError from '../../../utils/ExpressError.js';
 import { HydratedDocument } from 'mongoose';
 
+/**
+ * Shape of data in request body when creating EntryConversation
+ * TODO: consider moving this somewhere else. Might not be best fit here
+ * given that it's for enforcing user input
+ */
+interface MessageData {
+  messages: [
+    {
+      message_content: string,
+      llm_response: string
+    }
+  ]
+}
 
 /**
  * Returns array of all entries in a journal
@@ -78,6 +92,9 @@ export async function getEntryConversation(entryId: string) {
  * Creates a new Entry and corresponding EntryAnalysis in Journal
  * with journalId with entryContent as content
  *
+ * This function doesn't throw errors because the original controller
+ * handled them by creating a flash message with the error and continuing to
+ * respond noramlly.
  * @param journalId id of journal where creating new entry
  * @param configId id of config to use
  * @param entryContent body of entry, see EntryType
@@ -132,4 +149,58 @@ export async function createEntry(
     await newAnalysis.save();
   }
   return createEntryResult;
+}
+
+/**
+ * TODO: continue breaking up this function
+ * Creates new EntryConversation for an Entry and populates with LLM response
+ * 
+ * This function throws errors to replicate how the original function
+ * handled them, which was to create a new error and call the error handler.
+ * The controller is responsible for catching errors and calling
+ * the error handler when using this function.
+ * @param entryId id of Entry to create EntryConversation for
+ * @param messageData user-submitted messages to create conversation for
+ * @param configId id of Config for LLM
+ * @returns new EntryConversation from messageData
+ */
+export async function createEntryConversation(
+  entryId: string,
+  configId: string,
+  messageData: MessageData
+) {
+  // Get an entry with the analysis
+  const entry = await Entry.findById(entryId);
+  if (!entry) {
+    throw new ExpressError('Entry not found.', 404);
+  }
+  if (!entry.analysis) {
+    throw new ExpressError('Entry analysis not found.', 404);
+  }
+  
+  const newConversation = new EntryConversation({
+    entry: entryId,
+    ...messageData,
+  });
+  
+  // Associate the conversation with the entry
+  entry.conversation = newConversation.id;
+  await entry.save();
+  
+  const llmResponse = await newConversation.getChatContent(
+    configId,
+    entry.analysis.toString(),
+    messageData.messages[0].message_content
+  );
+  
+  // If the chat is not empty, update the llm_response
+  if (!newConversation.messages) {
+    throw new ExpressError('No message to get completion for.', 404);
+  }
+  if (llmResponse) {
+    newConversation.messages[0].llm_response = llmResponse;
+  }
+  await newConversation.save();
+
+  return newConversation;
 }

--- a/backend/src/models/services/entry/entry.ts
+++ b/backend/src/models/services/entry/entry.ts
@@ -1,173 +1,209 @@
-import mongoose, { HydratedDocument } from 'mongoose';
-import { EntryType } from '../../entry/entry.js';
-import { EntryAnalysisType } from '../../entry/entryAnalysis.js';
 import {
   Config,
   Entry,
   EntryAnalysis,
   EntryConversation,
-  Journal,
 } from '../../index.js';
 import CdGpt from '../../../assistants/gpts/CdGpt.js';
+import { EntryAnalysisType } from '../../entry/entryAnalysis.js';
+import { EntryConversationType } from '../../entry/entryConversation.js';
+import { EntryType } from '../../entry/entry.js';
+import { HydratedDocument } from 'mongoose';
 
-export namespace EntryServices {
-  /**
-   * Returns array of all entries in a journal
-   * @param journalId Journal._id as string
-   * @returns array of documents in journal with journalId
-   */
-  export async function getAllEntriesInJournal(
-    journalId: string
-  ): Promise<HydratedDocument<EntryType>[]> {
-    try {
-      let res = await Entry.find({ journal: journalId });
-      return res;
-    } catch (err) {
-      console.log(err);
-    }
-    return [];
+
+/**
+ * Returns array of all entries in a journal
+ * @param journalId Journal._id as string
+ * @returns array of documents in journal with journalId
+ */
+export async function getAllEntriesInJournal(
+  journalId: string
+): Promise<HydratedDocument<EntryType>[]> {
+  try {
+    const res = await Entry.find({ journal: journalId });
+    return res;
+  } catch (err) {
+    console.error(err);
   }
+  return [];
+}
 
-  /**
-   * Creates a new entry in journalId with entryContent as content
-   * @param journalId Journal._id as string
-   * @param entryContent body of entry
-   * @returns new Entry document on success, and null on error.
-   */
-  export async function createEntry(
-    journalId: string,
-    entryContent: object
-  ): Promise<HydratedDocument<EntryType> | null> {
-    /**
-     * TODO: may want to define entryContent type.
-     * Currently, it's based on EntryValidation and Entry joi schemas together b/c validation middleware.
-     * Takes on validation value but b/c mongoose strict mode, non-schema fields are dropped
-     */
-    try {
-      const newEntry = await Entry.create({ journal: journalId, ...entryContent });
-      return newEntry;
-    } catch (err) {
-      console.log(err);
-    }
-    return null;
+/**
+ * Gets Entry with all referenced properties populated
+ * @param entryId string of Entry._id to get
+ * @param paths string of properties to populate
+ * @returns Populated entry document
+ */
+export async function getPopulatedEntry(entryId: string) {
+  return await Entry
+    .findById(entryId)
+    .populate<{
+      analysis: EntryAnalysisType,
+      conversation: EntryConversationType
+    }>('analysis conversation');
+}
+
+/**
+ * Gets EntryAnalysis corresponding to entryId and populates with its Entry
+ * @param entryId 
+ * @returns 
+ */
+export async function getPopluatedEntryAnalysis(entryId: string) {
+  try {
+    return await EntryAnalysis
+      .findOne({ entry: entryId })
+      .populate<{
+        entry: EntryType,
+      }>('entry');
+  } catch (err) {
+    console.error(err);
   }
+  return null;
+}
 
+/**
+ * Gets EntryConversation corresponding to entryId
+ * @param entryId 
+ * @returns 
+ */
+export async function getEntryConversation(entryId: string) {
+  try {
+    return await EntryConversation.findOne({ entry: entryId });
+  } catch (err) {
+    console.error(err);
+  }
+  return null;
+}
+
+// TODO: All functions below are in-progress. DL will be working on them in other PRs
+
+/**
+ * Creates a new entry in journalId with entryContent as content
+ * @param journalId Journal._id as string
+ * @param entryContent body of entry
+ * @returns new Entry document on success, and null on error.
+ */
+export async function createEntry(
+  journalId: string,
+  entryContent: object
+): Promise<HydratedDocument<EntryType> | null> {
   /**
-   * Creates empty EntryAnalysis for an Entry, and updates entry with
-   * refernces to new EntryAnalysis.
-   * @param configId Config._id as string
-   * @param refEntry Document of target Entry to generate analysis for
-   * @returns new EntryAnalysis for refEntry
+   * TODO: may want to define entryContent type.
+   * Currently, it's based on EntryValidation and Entry joi schemas together b/c validation middleware.
+   * Takes on validation value but b/c mongoose strict mode, non-schema fields are dropped
    */
-  export async function createEntryAnalysis(
-    configId: string,
-    refEntry: HydratedDocument<EntryType>
-  ): Promise<HydratedDocument<EntryAnalysisType>> {
-    const newAnalysis = await EntryAnalysis.create({
-      entry: refEntry.id,
-    });
+  try {
+    const newEntry = await Entry.create({ journal: journalId, ...entryContent });
+    return newEntry;
+  } catch (err) {
+    console.error(err);
+  }
+  return null;
+}
 
-    // Associate the entry with the analysis
-    refEntry.analysis = newAnalysis.id;
+/**
+ * Creates empty EntryAnalysis for an Entry, and updates entry with
+ * refernces to new EntryAnalysis.
+ * @param configId Config._id as string
+ * @param refEntry Document of target Entry to generate analysis for
+ * @returns new EntryAnalysis for refEntry
+ */
+export async function createEntryAnalysis(
+  configId: string,
+  refEntry: HydratedDocument<EntryType>
+): Promise<HydratedDocument<EntryAnalysisType>> {
+  const newAnalysis = await EntryAnalysis.create({
+    entry: refEntry.id,
+  });
+
+  // Associate the entry with the analysis
+  refEntry.analysis = newAnalysis.id;
+  await refEntry.save();
+
+  return newAnalysis;
+}
+
+/**
+ * Generates analysis body for refEntry, and updates refEntry and refAnalysis
+ * with analysis response.
+ * @param configId Config._id as string
+ * @param refEntry Document of target Entry to generate analysis for
+ * @param refAnalysis Document of EntryAnalysis to generate analysis for
+ */
+export async function populateAnalysisContent(
+  configId: string,
+  refEntry: HydratedDocument<EntryType>,
+  refAnalysis: HydratedDocument<EntryAnalysisType>
+): Promise<void> {
+  try {
+    const analysis = await refAnalysis.getAnalysisContent(
+      configId,
+      refEntry.content
+    );
+
+    // Complete the entry and analysis with the analysis content if available
+    if (analysis) {
+      refEntry.title = analysis.title;
+      refEntry.mood = analysis.mood;
+      refEntry.tags = analysis.tags;
+
+      refAnalysis.analysis_content = analysis.analysis_content;
+    }
     await refEntry.save();
-
-    return newAnalysis;
+    await refAnalysis.save();
+  } catch (err) {
+    console.error(err);
+    throw err;
   }
+}
 
-  /**
-   * Generates analysis body for refEntry, and updates refEntry and refAnalysis
-   * with analysis response.
-   * @param configId Config._id as string
-   * @param refEntry Document of target Entry to generate analysis for
-   * @param refAnalysis Document of EntryAnalysis to generate analysis for
-   */
-  export async function populateAnalysisContent(
-    configId: string,
-    refEntry: HydratedDocument<EntryType>,
-    refAnalysis: HydratedDocument<EntryAnalysisType>
-  ): Promise<void> {
+/**
+ * Calls LLM API to retrieve analysis for entry content.
+ * @param configId Config._id for LLM to use
+ * @param content user entry to generate analysis of
+ * @returns LLM analysis JSON
+ */
+async function getAnalysisContent(configId: string, content: string): Promise<any> {
+  const config = await Config.findById(configId);
+
+  if (!config) {
+    throw new Error('Configure your account settings to get an analysis.');
+  } else if (config.apiKey) {
     try {
-      const analysis = await getAnalysisContent(
-        configId,
-        refEntry.content
-      );
-
-      // Complete the entry and analysis with the analysis content if available
-      if (analysis) {
-        refEntry.title = analysis.title;
-        refEntry.mood = analysis.mood;
-        refEntry.tags = analysis.tags;
-
-        refAnalysis.analysis_content = analysis.analysis_content;
-      }
-      await refEntry.save();
-      await refAnalysis.save();
+      // Remove an API key from a legacy config
+      await Config.findByIdAndUpdate(config._id, { $unset: { apiKey: 1 } });
     } catch (err) {
-      console.log(err);
-      throw err;
+      if (typeof err === 'string') {
+        throw new Error(err);
+      } else if (err instanceof Error) {
+        throw err;
+      }
     }
   }
 
-  /**
-   * Calls LLM API to retrieve analysis for entry content.
-   * @param configId Config._id for LLM to use
-   * @param content user entry to generate analysis of
-   * @returns LLM analysis JSON
-   */
-  async function getAnalysisContent(configId: string, content: string): Promise<any> {
-    const config = await Config.findById(configId);
+  const cdGpt = new CdGpt(process.env.OPENAI_API_KEY, config.model.analysis);
 
-    if (!config) {
-      throw new Error('Configure your account settings to get an analysis.');
-    } else if (config.apiKey) {
-      try {
-        // Remove an API key from a legacy config
-        await Config.findByIdAndUpdate(config._id, { $unset: { apiKey: 1 } });
-      } catch (err) {
-        if (typeof err === "string") {
-          throw new Error(err);
-        } else if (err instanceof Error) {
-          throw err;
-        }
-      }
-    }
+  cdGpt.seedAnalysisMessages();
+  cdGpt.addUserMessage({ analysis: content });
 
-    const cdGpt = new CdGpt(process.env.OPENAI_API_KEY, config.model.analysis);
+  //TODO: replace type with better fitting one
+  const analysisCompletion: any = await cdGpt.getAnalysisCompletion();
 
-    cdGpt.seedAnalysisMessages();
-    cdGpt.addUserMessage({ analysis: content });
-
-    //TODO: replace type with better fitting one
-    const analysisCompletion: any = await cdGpt.getAnalysisCompletion();
-
-    if (analysisCompletion.error) {
-      throw new Error(analysisCompletion.error.message);
-    }
-
-    const response = JSON.parse(analysisCompletion.choices[0].message.content);
-
-    const { reframed_thought: reframing, distortion_analysis: analysis, impact_assessment: impact, affirmation, is_healthy: isHealthy } = response;
-
-    if (!isHealthy) {
-      if (!analysis || !impact || !reframing) {
-        throw new Error('Analysis content is not available.');
-      }
-
-      response.analysis_content = analysis + ' ' + impact + ' Think, "' + reframing + '"' || affirmation;
-    } else response.analysis_content = affirmation;
-
-    return response;
-  };
-
-  /**
-   * Gets Entry with populated properties
-   * @param entryId string of Entry._id to get
-   * @param paths string of properties to populate based on Mongoose API
-   * @returns Populated entry document
-   */
-  export async function getPopulatedEntry(entryId: string, paths: string) {
-    return await Entry
-      .findById(entryId)
-      .populate(paths);
+  if (analysisCompletion.error) {
+    throw new Error(analysisCompletion.error.message);
   }
+
+  const response = JSON.parse(analysisCompletion.choices[0].message.content);
+
+  const { reframed_thought: reframing, distortion_analysis: analysis, impact_assessment: impact, affirmation, is_healthy: isHealthy } = response;
+
+  if (!isHealthy) {
+    if (!analysis || !impact || !reframing) {
+      throw new Error('Analysis content is not available.');
+    }
+
+    response.analysis_content = analysis + ' ' + impact + ' Think, "' + reframing + '"' || affirmation;
+  } else response.analysis_content = affirmation;
+
+  return response;
 }

--- a/backend/src/models/services/entry/entry.ts
+++ b/backend/src/models/services/entry/entry.ts
@@ -1,10 +1,8 @@
 import {
-  Config,
   Entry,
   EntryAnalysis,
   EntryConversation,
 } from '../../index.js';
-import CdGpt from '../../../assistants/gpts/CdGpt.js';
 import { EntryAnalysisType } from '../../entry/entryAnalysis.js';
 import { EntryConversationType } from '../../entry/entryConversation.js';
 import { EntryType } from '../../entry/entry.js';
@@ -75,135 +73,48 @@ export async function getEntryConversation(entryId: string) {
   return null;
 }
 
-// TODO: All functions below are in-progress for create operations and are not being used currently. DL will be working on them in other PRs
-
 /**
- * Creates a new entry in journalId with entryContent as content
- * @param journalId Journal._id as string
- * @param entryContent body of entry
- * @returns new Entry document on success, and null on error.
+ * TODO: Continue breaking up this function. Move out EntryAnalysis creation and populating with content
+ * Creates a new Entry and corresponding EntryAnalysis in Journal
+ * with journalId with entryContent as content
+ *
+ * @param journalId id of journal where creating new entry
+ * @param configId id of config to use
+ * @param entryContent body of entry, see EntryType
+ * @returns new Entry document with reference to EntryAnalysis
  */
 export async function createEntry(
   journalId: string,
-  entryContent: object
-): Promise<HydratedDocument<EntryType> | null> {
-  /**
-   * TODO: may want to define entryContent type.
-   * Currently, it's based on EntryValidation and Entry joi schemas together b/c validation middleware.
-   * Takes on validation value but b/c mongoose strict mode, non-schema fields are dropped
-   */
-  try {
-    const newEntry = await Entry.create({ journal: journalId, ...entryContent });
-    return newEntry;
-  } catch (err) {
-    console.error(err);
-  }
-  return null;
-}
-
-/**
- * Creates empty EntryAnalysis for an Entry, and updates entry with
- * refernces to new EntryAnalysis.
- * @param configId Config._id as string
- * @param refEntry Document of target Entry to generate analysis for
- * @returns new EntryAnalysis for refEntry
- */
-export async function createEntryAnalysis(
   configId: string,
-  refEntry: HydratedDocument<EntryType>
-): Promise<HydratedDocument<EntryAnalysisType>> {
-  const newAnalysis = await EntryAnalysis.create({
-    entry: refEntry.id,
+  entryData: object): Promise<HydratedDocument<EntryType>> {
+  // Create new Entry and corresponding EntryAnalysis
+  const newEntry = new Entry({ journal: journalId, ...entryData });
+  const newAnalysis = new EntryAnalysis({
+    entry: newEntry.id,
   });
-
+  
   // Associate the entry with the analysis
-  refEntry.analysis = newAnalysis.id;
-  await refEntry.save();
-
-  return newAnalysis;
-}
-
-/**
- * Generates analysis body for refEntry, and updates refEntry and refAnalysis
- * with analysis response.
- * @param configId Config._id as string
- * @param refEntry Document of target Entry to generate analysis for
- * @param refAnalysis Document of EntryAnalysis to generate analysis for
- */
-export async function populateAnalysisContent(
-  configId: string,
-  refEntry: HydratedDocument<EntryType>,
-  refAnalysis: HydratedDocument<EntryAnalysisType>
-): Promise<void> {
+  newEntry.analysis = newAnalysis.id;
+  
+  // Get the analysis content for the entry
   try {
-    const analysis = await getAnalysisContent(
+    const analysis = await newAnalysis.getAnalysisContent(
       configId,
-      refEntry.content
+      newEntry.content
     );
-
+  
     // Complete the entry and analysis with the analysis content if available
     if (analysis) {
-      refEntry.title = analysis.title;
-      refEntry.mood = analysis.mood;
-      refEntry.tags = analysis.tags;
-
-      refAnalysis.analysis_content = analysis.analysis_content;
+      newEntry.title = analysis.title;
+      newEntry.mood = analysis.mood;
+      newEntry.tags = analysis.tags;
+  
+      // TODO: you might validate here instead, not use middleware
+      newAnalysis.analysis_content = analysis.analysis_content;
     }
-    await refEntry.save();
-    await refAnalysis.save();
-  } catch (err) {
-    console.error(err);
-    throw err;
+  } finally {
+    await newEntry.save();
+    await newAnalysis.save();
   }
-}
-
-/**
- * Calls LLM API to retrieve analysis for entry content.
- * @param configId Config._id for LLM to use
- * @param content user entry to generate analysis of
- * @returns LLM analysis JSON
- */
-async function getAnalysisContent(configId: string, content: string): Promise<any> {
-  const config = await Config.findById(configId);
-
-  if (!config) {
-    throw new Error('Configure your account settings to get an analysis.');
-  } else if (config.apiKey) {
-    try {
-      // Remove an API key from a legacy config
-      await Config.findByIdAndUpdate(config._id, { $unset: { apiKey: 1 } });
-    } catch (err) {
-      if (typeof err === 'string') {
-        throw new Error(err);
-      } else if (err instanceof Error) {
-        throw err;
-      }
-    }
-  }
-
-  const cdGpt = new CdGpt(process.env.OPENAI_API_KEY, config.model.analysis);
-
-  cdGpt.seedAnalysisMessages();
-  cdGpt.addUserMessage({ analysis: content });
-
-  //TODO: replace type with better fitting one
-  const analysisCompletion: any = await cdGpt.getAnalysisCompletion();
-
-  if (analysisCompletion.error) {
-    throw new Error(analysisCompletion.error.message);
-  }
-
-  const response = JSON.parse(analysisCompletion.choices[0].message.content);
-
-  const { reframed_thought: reframing, distortion_analysis: analysis, impact_assessment: impact, affirmation, is_healthy: isHealthy } = response;
-
-  if (!isHealthy) {
-    if (!analysis || !impact || !reframing) {
-      throw new Error('Analysis content is not available.');
-    }
-
-    response.analysis_content = analysis + ' ' + impact + ' Think, "' + reframing + '"' || affirmation;
-  } else response.analysis_content = affirmation;
-
-  return response;
+  return newEntry;
 }

--- a/backend/src/models/services/entry/entry.ts
+++ b/backend/src/models/services/entry/entry.ts
@@ -86,7 +86,11 @@ export async function getEntryConversation(entryId: string) {
 export async function createEntry(
   journalId: string,
   configId: string,
-  entryData: object): Promise<HydratedDocument<EntryType>> {
+  entryData: object,
+): Promise<{
+    errMessage?: string,
+    entry: HydratedDocument<EntryType>,
+  }> {
   // Create new Entry and corresponding EntryAnalysis
   const newEntry = new Entry({ journal: journalId, ...entryData });
   const newAnalysis = new EntryAnalysis({
@@ -95,7 +99,15 @@ export async function createEntry(
   
   // Associate the entry with the analysis
   newEntry.analysis = newAnalysis.id;
-  
+
+  // Creating return object to push error handling into service rather than controller
+  const createEntryResult: {
+    errMessage?: string,
+    entry: HydratedDocument<EntryType>,
+  } = {
+    entry: newEntry,
+  };
+
   // Get the analysis content for the entry
   try {
     const analysis = await newAnalysis.getAnalysisContent(
@@ -112,9 +124,12 @@ export async function createEntry(
       // TODO: you might validate here instead, not use middleware
       newAnalysis.analysis_content = analysis.analysis_content;
     }
+  } catch (err) {
+    console.error(err);
+    createEntryResult.errMessage = (err as Error).message;
   } finally {
     await newEntry.save();
     await newAnalysis.save();
   }
-  return newEntry;
+  return createEntryResult;
 }

--- a/backend/src/models/user.ts
+++ b/backend/src/models/user.ts
@@ -30,7 +30,6 @@ export interface UserType extends PassportLocalDocument {
   betaAccessToken?: string,
   betaAccessTokenExpires?: Date,
   betaAccess?: boolean,
-  id: string // Added for compatibility with Express.User
 
   // Instance Methods
   comparePassword(candidatePassword: string): Promise<unknown>,

--- a/backend/src/models/user.ts
+++ b/backend/src/models/user.ts
@@ -16,7 +16,7 @@ import passportLocalMongoose from 'passport-local-mongoose';
 
 if (process.env.NODE_ENV !== 'production') dotenv.config();
 
-export interface UserType extends PassportLocalDocument, Express.User {
+export interface UserType extends PassportLocalDocument {
   fname: string,
   lname: string,
   email: string,

--- a/backend/src/types/express/index.d.ts
+++ b/backend/src/types/express/index.d.ts
@@ -1,12 +1,14 @@
-/** This file is used to extend Express types with custom properties. 
+/** This file is used to extend Express types to match CDJ models with declaration merging. 
  * 
- * Note that Passport extends the Request object with a user property. To use
- * id on the Express.User type, Express.User must be extended to include id 
- * that passport sets on the user object.
+ * Passport extends global.Express.User for use in its extension of global.Express.Request
+ * We extend global.Express.User to match the CDJ's UserType.
  */
 
-declare namespace Express {
-  interface User {
-    id: string; 
+import { UserType } from '../../models/user.ts';
+
+declare global {
+  namespace Express {
+    // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+    interface User extends UserType {}
   }
 }

--- a/backend/tests/models/services/entry/entry.test.ts
+++ b/backend/tests/models/services/entry/entry.test.ts
@@ -2,20 +2,27 @@
  * @jest-environment node
  */
 
-import { Config, Entry, Journal, User } from "../../../../src/models/index.js";
-import mongoose from "mongoose";
-import connectDB from "../../../../src/db.js";
-import { EntryServices } from "../../../../src/models/services/entry/entry.js";
-import { EntryType } from "../../../../src/models/entry/entry.js";
+import * as EntryServices from '../../../../src/models/services/entry/entry.js';
+import { Entry, EntryAnalysis, EntryConversation, Journal, User } from '../../../../src/models/index.js';
+import mongoose, { HydratedDocument } from 'mongoose';
+import { EntryType } from '../../../../src/models/entry/entry.js';
+import { JournalType } from '../../../../src/models/journal.js';
+import { UserType } from '../../../../src/models/user.js';
+import connectDB from '../../../../src/db.js';
 
-jest.mock("../../../../src/models/entry/entryAnalysis.js");
-describe('entry controller tests', () => {
+describe('Entry service tests', () => {
+  const NULL_CHECK_MESSAGE = 'EntryService function return should not be null in this test';
+  let mockUser: HydratedDocument<UserType>;
+  let mockJournal: HydratedDocument<JournalType>;
+
   beforeAll(async () => {
-    await connectDB("cdj");
+    await connectDB('cdj');
   });
 
   beforeEach(async () => {
     await mongoose.connection.dropDatabase();
+    mockUser = await User.create({ fname: 'test', lname: 'test', email: 'testEmail@gmail.com' });
+    mockJournal = await Journal.create({ user: mockUser.id });
   });
 
   afterAll(async () => {
@@ -23,64 +30,127 @@ describe('entry controller tests', () => {
   });
 
   it('gets no entries in an empty journal', async () => {
-    const mockUser = new User({ fname: "test", lname: "test" });
-    const mockJournal = new Journal({ user: mockUser.id });
-    await mockUser.save();
-    await mockJournal.save();
-
     const entries = await EntryServices.getAllEntriesInJournal(mockJournal.id);
 
-    expect(entries.length).toBe(0);
+    expect(entries).toHaveLength(0);
+  });
+
+  it('returns empty list on error when getting all entries', async () => {
+    const entries = await EntryServices.getAllEntriesInJournal('bad id');
+
+    expect(entries).toHaveLength(0);
   });
 
   it('gets all entries in a journal', async () => {
-    const mockUser = new User({ fname: "test", lname: "test" });
-    const mockJournal = new Journal({ user: mockUser.id });
-    await mockUser.save();
-    await mockJournal.save();
-    const mockEntry1 = new Entry({ journal: mockJournal.id, content: "mock content" });
-    const mockEntry2 = new Entry({ journal: mockJournal.id, content: "mock content" });
+    const mockEntry1 = new Entry({ journal: mockJournal.id, content: 'mock content' });
+    const mockEntry2 = new Entry({ journal: mockJournal.id, content: 'mock content' });
     await mockEntry1.save();
     await mockEntry2.save();
 
     const entries = await EntryServices.getAllEntriesInJournal(mockJournal.id);
 
-    expect(entries.length).toBe(2);
+    expect(entries).toHaveLength(2);
   });
 
   it('gets entries from only one journal', async () => {
-    const mockUser = new User({ fname: "test", lname: "test" });
-    const mockJournal1 = new Journal({ user: mockUser.id });
     const mockJournal2 = new Journal({ user: mockUser.id });
-    const mockEntry1 = new Entry({ journal: mockJournal1.id, content: "mock content" });
-    const mockEntry2 = new Entry({ journal: mockJournal2.id, content: "mock content" });
+    const mockEntry1 = new Entry({ journal: mockJournal.id, content: 'mock content' });
+    const mockEntry2 = new Entry({ journal: mockJournal2.id, content: 'mock content' });
     await mockEntry1.save();
     await mockEntry2.save();
 
-    const entries1 = await EntryServices.getAllEntriesInJournal(mockJournal1.id);
+    const entries1 = await EntryServices.getAllEntriesInJournal(mockJournal.id);
     const entries2 = await EntryServices.getAllEntriesInJournal(mockJournal2.id);
 
-    expect(entries1.length).toBe(1);
-    expect(entries2.length).toBe(1);
+    expect(entries1).toHaveLength(1);
+    expect(entries2).toHaveLength(1);
+  });
+
+  it('gets Entry by entryId populated with EntryAnalysis and EntryConversation', async () => {
+    const mockEntry = new Entry({ journal: mockJournal.id, content: 'mock content' });
+    const mockAnalysis = new EntryAnalysis({ entry: mockEntry, analysis_content: 'test content', created_at: new Date(0), updated_at: new Date(0) });
+    const mockConversation = new EntryConversation({ entry: mockEntry, messages: [] });
+    mockEntry.analysis = mockAnalysis.id;
+    mockEntry.conversation = mockConversation.id;
+    await mockAnalysis.save();
+    await mockConversation.save();
+    await mockEntry.save();
+
+    const sut = await EntryServices.getPopulatedEntry(mockEntry.id);
+
+    if (sut === null) {
+      expect(NULL_CHECK_MESSAGE).toBe(false);
+      return;
+    }
+    expect(sut.id).toBe(mockEntry.id);
+    expect(sut.analysis.entry.toHexString()).toBe(mockEntry.id);
+    expect(sut.analysis.analysis_content).toBe('test content');
+    expect(sut.analysis.created_at).toBeDefined();
+    expect(sut.analysis.updated_at).toBeDefined();
+    expect(sut.conversation.entry.toHexString()).toBe(mockEntry.id);
+    expect(sut.conversation.messages).toBeDefined();
+  });
+
+  it('gets EntryAnalysis by entryId entry populated with Entry', async () => {
+    const mockEntry = new Entry({ journal: mockJournal.id, content: 'mock content' });
+    const mockAnalysis = new EntryAnalysis({ entry: mockEntry, analysis_content: 'test content', created_at: new Date(0), updated_at: new Date(0) });
+    mockEntry.analysis = mockAnalysis.id;
+    await mockAnalysis.save();
+    await mockEntry.save();
+
+    const sut = await EntryServices.getPopluatedEntryAnalysis(mockEntry.id);
+    if (sut === null) {
+      expect(NULL_CHECK_MESSAGE).toBe(false);
+      return;
+    }
+
+    expect(sut.id).toBe(mockAnalysis.id);
+    expect(sut.entry.content).toBe('mock content');
+    expect(sut.entry.journal.toHexString()).toBe(mockJournal.id);
+  });
+
+  it('returns null on error when getting populated EntryAnalysis', async () => {
+    const sut = await EntryServices.getPopluatedEntryAnalysis('bad id');
+    
+    expect(sut).toBeNull();
+  });
+
+  it('gets EntryConversation by entryId', async () => {
+    const mockEntry = new Entry({ journal: mockJournal.id, content: 'mock content' });
+    const mockConversation = new EntryConversation({ entry: mockEntry, messages: [] });
+    await mockConversation.save();
+    await mockEntry.save();
+
+    const sut = await EntryServices.getEntryConversation(mockEntry.id);
+    if (sut === null) {
+      expect(NULL_CHECK_MESSAGE).toBe(false);
+      return;
+    }
+
+    expect(sut.id).toBe(mockConversation.id);
+  });
+
+  it('returns null on error when getting EntryConversation', async () => {
+    const sut = await EntryServices.getEntryConversation('bad id');
+    
+    expect(sut).toBeNull();
   });
 
   it('creates entries with valid journal id and content', async () => {
-    const mockUser = new User({ fname: "test", lname: "test" });
-    const mockConfig = new Config({ model: { chat: 'gpt-3.5-turbo', analysis: 'gpt-4-1106-preview' } });
-    const mockJournal = new Journal({ user: mockUser.id, config: mockConfig.id });
-    await mockUser.save();
-    await mockConfig.save();
-    await mockJournal.save();
     const mockEntryContent: EntryType = {
       journal: mockJournal.id,
-      content: "mock content",
+      content: 'mock content',
     };
 
     const sut = await EntryServices.createEntry(mockJournal.id, mockEntryContent);
+    if (sut === null) {
+      expect(NULL_CHECK_MESSAGE).toBe(false);
+      return;
+    }
 
-    expect(sut.title).toBe("Untitled");
+    expect(sut.title).toBe('Untitled');
     expect(sut.journal.toString()).toBe(mockJournal.id);
-    expect(sut.content).toBe("mock content");
+    expect(sut.content).toBe('mock content');
     expect(sut.tags).toStrictEqual([]);
     expect(sut.analysis).toBeUndefined();
   });

--- a/backend/tests/models/services/entry/entry.test.ts
+++ b/backend/tests/models/services/entry/entry.test.ts
@@ -169,4 +169,24 @@ describe('Entry service tests', () => {
     expect(sut.analysis?.toString()).toBe(testAnalysis?.id);
     expect(testAnalysis?.analysis_content).toBe(mockAnalysisContent.analysis_content);
   });
+
+  it('creates and saves EntryConversation with valid input', async () => {
+    expect(true).toBe(false);
+  });
+
+  it('throws error on missing entry when creating EntryConversation', async () => {
+    expect(true).toBe(false);
+  });
+
+  it('throws error on missing entry.analysis when creating EntryConversation', async () => {
+    expect(true).toBe(false);
+  });
+
+  it('throws error when new EntryConversation has empty messages', async () => {
+    expect(true).toBe(false);
+  });
+
+  it('does not update EntryConversation if llm response is empty', async () => {
+    expect(true).toBe(false);
+  });
 });

--- a/backend/tests/models/services/entry/entry.test.ts
+++ b/backend/tests/models/services/entry/entry.test.ts
@@ -83,11 +83,11 @@ describe('Entry service tests', () => {
       return;
     }
     expect(sut.id).toBe(mockEntry.id);
-    expect(sut.analysis.entry.toHexString()).toBe(mockEntry.id);
+    expect(sut.analysis.entry.toString()).toBe(mockEntry.id);
     expect(sut.analysis.analysis_content).toBe('test content');
     expect(sut.analysis.created_at).toBeDefined();
     expect(sut.analysis.updated_at).toBeDefined();
-    expect(sut.conversation.entry.toHexString()).toBe(mockEntry.id);
+    expect(sut.conversation.entry.toString()).toBe(mockEntry.id);
     expect(sut.conversation.messages).toBeDefined();
   });
 
@@ -106,7 +106,7 @@ describe('Entry service tests', () => {
 
     expect(sut.id).toBe(mockAnalysis.id);
     expect(sut.entry.content).toBe('mock content');
-    expect(sut.entry.journal.toHexString()).toBe(mockJournal.id);
+    expect(sut.entry.journal.toString()).toBe(mockJournal.id);
   });
 
   it('returns null on error when getting populated EntryAnalysis', async () => {

--- a/backend/tests/models/services/entry/entry.test.ts
+++ b/backend/tests/models/services/entry/entry.test.ts
@@ -1,0 +1,109 @@
+/**
+ * @jest-environment node
+ */
+
+import { Config, Entry, Journal, User } from "../../../../src/models/index.js";
+import mongoose from "mongoose";
+import connectDB from "../../../../src/db.js";
+import { EntryServices } from "../../../../src/models/services/entry/entry.js";
+import { EntryType } from "../../../../src/models/entry/entry.js";
+
+jest.mock("../../../../src/models/entry/entryAnalysis.js");
+describe('entry controller tests', () => {
+  beforeAll(async () => {
+    await connectDB("cdj");
+  });
+
+  beforeEach(async () => {
+    await mongoose.connection.dropDatabase();
+  });
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+  });
+
+  it('gets no entries in an empty journal', async () => {
+    const mockUser = new User({ fname: "test", lname: "test" });
+    const mockJournal = new Journal({ user: mockUser.id });
+    await mockUser.save();
+    await mockJournal.save();
+
+    const entries = await EntryServices.getAllEntries(mockJournal.id);
+
+    expect(entries.length).toBe(0);
+  });
+
+  it('gets all entries in a journal', async () => {
+    const mockUser = new User({ fname: "test", lname: "test" });
+    const mockJournal = new Journal({ user: mockUser.id });
+    await mockUser.save();
+    await mockJournal.save();
+    const mockEntry1 = new Entry({ journal: mockJournal.id, content: "mock content" });
+    const mockEntry2 = new Entry({ journal: mockJournal.id, content: "mock content" });
+    await mockEntry1.save();
+    await mockEntry2.save();
+
+    const entries = await EntryServices.getAllEntries(mockJournal.id);
+
+    expect(entries.length).toBe(2);
+  });
+
+  it('gets entries from only one journal', async () => {
+    const mockUser = new User({ fname: "test", lname: "test" });
+    const mockJournal1 = new Journal({ user: mockUser.id });
+    const mockJournal2 = new Journal({ user: mockUser.id });
+    const mockEntry1 = new Entry({ journal: mockJournal1.id, content: "mock content" });
+    const mockEntry2 = new Entry({ journal: mockJournal2.id, content: "mock content" });
+    await mockEntry1.save();
+    await mockEntry2.save();
+
+    const entries1 = await EntryServices.getAllEntries(mockJournal1.id);
+    const entries2 = await EntryServices.getAllEntries(mockJournal2.id);
+
+    expect(entries1.length).toBe(1);
+    expect(entries2.length).toBe(1);
+  });
+
+  it('can create entry if journal exists', async () => {
+    const mockUser = new User({ fname: "test", lname: "test" });
+    const mockJournal = new Journal({ user: mockUser.id });
+    await mockJournal.save();
+
+    const sut = await EntryServices.canCreateEntry(mockJournal.id);
+
+    expect(sut).toBe(true);
+  });
+
+  it('cannot create entry if journal does not exist', async () => {
+    const mockUser = new User({ fname: "test", lname: "test" });
+    const mockJournal = new Journal({ user: mockUser.id });
+
+    const sut = await EntryServices.canCreateEntry(mockJournal.id);
+
+    expect(sut).toBe(false);
+  });
+
+  it('creates entries with valid journal id and content', async () => {
+    const mockUser = new User({ fname: "test", lname: "test" });
+    const mockConfig = new Config({ model: { chat: 'gpt-3.5-turbo', analysis: 'gpt-4-1106-preview' } });
+    const mockJournal = new Journal({ user: mockUser.id, config: mockConfig.id });
+    await mockUser.save();
+    await mockConfig.save();
+    await mockJournal.save();
+    const mockEntryContent: EntryType = {
+      journal: mockJournal.id,
+      content: "mock content",
+    };
+
+    const sut = await EntryServices.createEntry(mockJournal.id, mockEntryContent);
+
+    expect(sut.title).toBe("Untitled");
+    expect(sut.journal.toString()).toBe(mockJournal.id);
+    expect(sut.content).toBe("mock content");
+    expect(sut.tags).toStrictEqual([]);
+    expect(sut.analysis).toBeUndefined();
+  });
+
+  it('creates entries', async () => { });
+
+});

--- a/backend/tests/models/services/entry/entry.test.ts
+++ b/backend/tests/models/services/entry/entry.test.ts
@@ -131,9 +131,10 @@ describe('Entry service tests', () => {
     const mockConfig = await Config.create({ model: {} });
     jest.spyOn(EntryAnalysis.prototype, 'getAnalysisContent').mockResolvedValue(undefined);
 
-    const sut = await EntryServices.createEntry(mockJournal.id, mockConfig.id, mockEntryContent);
+    const { errMessage, entry: sut } = await EntryServices.createEntry(mockJournal.id, mockConfig.id, mockEntryContent);
     const testAnalysis = await EntryAnalysis.findById(sut.analysis);
 
+    expect(errMessage).toBeUndefined();
     expect(sut.title).toBe('Untitled');
     expect(sut.journal.toString()).toBe(mockJournal.id);
     expect(sut.content).toBe('mock content');
@@ -156,9 +157,10 @@ describe('Entry service tests', () => {
     };
     jest.spyOn(EntryAnalysis.prototype, 'getAnalysisContent').mockResolvedValue(mockAnalysisContent);
 
-    const sut = await EntryServices.createEntry(mockJournal.id, mockConfig.id, mockEntryContent);
+    const { errMessage, entry: sut } = await EntryServices.createEntry(mockJournal.id, mockConfig.id, mockEntryContent);
     const testAnalysis = await EntryAnalysis.findById(sut.analysis);
 
+    expect(errMessage).toBeUndefined();
     expect(sut.title).toBe(mockAnalysisContent.title);
     expect(sut.journal.toString()).toBe(mockJournal.id);
     expect(sut.mood).toBe(mockAnalysisContent.mood);

--- a/backend/tests/models/services/entry/entry.test.ts
+++ b/backend/tests/models/services/entry/entry.test.ts
@@ -3,7 +3,7 @@
  */
 
 import * as EntryServices from '../../../../src/models/services/entry/entry.js';
-import { Entry, EntryAnalysis, EntryConversation, Journal, User } from '../../../../src/models/index.js';
+import { Config, Entry, EntryAnalysis, EntryConversation, Journal, User } from '../../../../src/models/index.js';
 import mongoose, { HydratedDocument } from 'mongoose';
 import { EntryType } from '../../../../src/models/entry/entry.js';
 import { JournalType } from '../../../../src/models/journal.js';
@@ -11,7 +11,6 @@ import { UserType } from '../../../../src/models/user.js';
 import connectDB from '../../../../src/db.js';
 
 describe('Entry service tests', () => {
-  const NULL_CHECK_MESSAGE = 'EntryService function return should not be null in this test';
   let mockUser: HydratedDocument<UserType>;
   let mockJournal: HydratedDocument<JournalType>;
 
@@ -78,17 +77,13 @@ describe('Entry service tests', () => {
 
     const sut = await EntryServices.getPopulatedEntry(mockEntry.id);
 
-    if (sut === null) {
-      expect(NULL_CHECK_MESSAGE).toBe(false);
-      return;
-    }
-    expect(sut.id).toBe(mockEntry.id);
-    expect(sut.analysis.entry.toString()).toBe(mockEntry.id);
-    expect(sut.analysis.analysis_content).toBe('test content');
-    expect(sut.analysis.created_at).toBeDefined();
-    expect(sut.analysis.updated_at).toBeDefined();
-    expect(sut.conversation.entry.toString()).toBe(mockEntry.id);
-    expect(sut.conversation.messages).toBeDefined();
+    expect(sut?.id).toBe(mockEntry.id);
+    expect(sut?.analysis.entry.toString()).toBe(mockEntry.id);
+    expect(sut?.analysis.analysis_content).toBe('test content');
+    expect(sut?.analysis.created_at).toBeDefined();
+    expect(sut?.analysis.updated_at).toBeDefined();
+    expect(sut?.conversation.entry.toString()).toBe(mockEntry.id);
+    expect(sut?.conversation.messages).toBeDefined();
   });
 
   it('gets EntryAnalysis by entryId entry populated with Entry', async () => {
@@ -99,14 +94,10 @@ describe('Entry service tests', () => {
     await mockEntry.save();
 
     const sut = await EntryServices.getPopluatedEntryAnalysis(mockEntry.id);
-    if (sut === null) {
-      expect(NULL_CHECK_MESSAGE).toBe(false);
-      return;
-    }
 
-    expect(sut.id).toBe(mockAnalysis.id);
-    expect(sut.entry.content).toBe('mock content');
-    expect(sut.entry.journal.toString()).toBe(mockJournal.id);
+    expect(sut?.id).toBe(mockAnalysis.id);
+    expect(sut?.entry.content).toBe('mock content');
+    expect(sut?.entry.journal.toString()).toBe(mockJournal.id);
   });
 
   it('returns null on error when getting populated EntryAnalysis', async () => {
@@ -122,12 +113,8 @@ describe('Entry service tests', () => {
     await mockEntry.save();
 
     const sut = await EntryServices.getEntryConversation(mockEntry.id);
-    if (sut === null) {
-      expect(NULL_CHECK_MESSAGE).toBe(false);
-      return;
-    }
 
-    expect(sut.id).toBe(mockConversation.id);
+    expect(sut?.id).toBe(mockConversation.id);
   });
 
   it('returns null on error when getting EntryConversation', async () => {
@@ -136,25 +123,48 @@ describe('Entry service tests', () => {
     expect(sut).toBeNull();
   });
 
-  it('creates entries with valid journal id and content', async () => {
+  it('creates Entry with valid journal id, config id, and content', async () => {
     const mockEntryContent: EntryType = {
       journal: mockJournal.id,
       content: 'mock content',
     };
+    const mockConfig = await Config.create({ model: {} });
+    jest.spyOn(EntryAnalysis.prototype, 'getAnalysisContent').mockResolvedValue(undefined);
 
-    const sut = await EntryServices.createEntry(mockJournal.id, mockEntryContent);
-    if (sut === null) {
-      expect(NULL_CHECK_MESSAGE).toBe(false);
-      return;
-    }
+    const sut = await EntryServices.createEntry(mockJournal.id, mockConfig.id, mockEntryContent);
+    const testAnalysis = await EntryAnalysis.findById(sut.analysis);
 
     expect(sut.title).toBe('Untitled');
     expect(sut.journal.toString()).toBe(mockJournal.id);
     expect(sut.content).toBe('mock content');
     expect(sut.tags).toStrictEqual([]);
-    expect(sut.analysis).toBeUndefined();
+    expect(sut.analysis?.toString()).toBe(testAnalysis?.id);
+    expect(testAnalysis?.analysis_content).toBe('Analysis not available');
   });
 
-  it('creates entries', async () => { });
+  it('creates Entry with valid journal id, config id, and content with analysis returned', async () => {
+    const mockEntryContent: EntryType = {
+      journal: mockJournal.id,
+      content: 'mock content',
+    };
+    const mockConfig = await Config.create({ model: {} });
+    const mockAnalysisContent = {
+      title: 'Mock Title',
+      mood: 'mock mood',
+      tags: ['test', 'mock'],
+      analysis_content: 'mock analysis content',
+    };
+    jest.spyOn(EntryAnalysis.prototype, 'getAnalysisContent').mockResolvedValue(mockAnalysisContent);
 
+    const sut = await EntryServices.createEntry(mockJournal.id, mockConfig.id, mockEntryContent);
+    const testAnalysis = await EntryAnalysis.findById(sut.analysis);
+
+    expect(sut.title).toBe(mockAnalysisContent.title);
+    expect(sut.journal.toString()).toBe(mockJournal.id);
+    expect(sut.mood).toBe(mockAnalysisContent.mood);
+    expect(sut.content).toBe('mock content');
+    expect(sut.tags).toStrictEqual(mockAnalysisContent.tags);
+    expect(sut.analysis?.toString()).toBe(testAnalysis?.id);
+    expect(testAnalysis?.analysis_content).toBe(mockAnalysisContent.analysis_content);
+  });
 });

--- a/backend/tests/models/services/entry/entry.test.ts
+++ b/backend/tests/models/services/entry/entry.test.ts
@@ -172,6 +172,27 @@ describe('Entry service tests', () => {
     expect(testAnalysis?.analysis_content).toBe(mockAnalysisContent.analysis_content);
   });
 
+  it('returns error message when getting analysis content throws error', async () => {
+    const mockEntryContent: EntryType = {
+      journal: mockJournal.id,
+      content: 'mock content',
+    };
+    const mockConfig = await Config.create({ model: {} });
+    jest.spyOn(EntryAnalysis.prototype, 'getAnalysisContent').mockRejectedValue(new Error('test error message'));
+
+    const { errMessage, entry: sut } = await EntryServices.createEntry(mockJournal.id, mockConfig.id, mockEntryContent);
+    const testAnalysis = await EntryAnalysis.findById(sut.analysis);
+
+    expect(errMessage).toBe('test error message');
+    expect(sut.title).toBe('Untitled');
+    expect(sut.journal.toString()).toBe(mockJournal.id);
+    expect(sut.mood).toBeUndefined();
+    expect(sut.content).toBe('mock content');
+    expect(sut.tags).toStrictEqual([]);
+    expect(sut.analysis?.toString()).toBe(testAnalysis?.id);
+    expect(testAnalysis?.analysis_content).toBe('Analysis not available');
+  });
+
   it('creates and saves EntryConversation with valid input', async () => {
     const mockEntry = new Entry({ journal: mockJournal.id, content: 'mock content' });
     const mockEntryAnalysis = await EntryAnalysis.create({ entry: mockEntry.id });

--- a/backend/tests/models/services/entry/entry.test.ts
+++ b/backend/tests/models/services/entry/entry.test.ts
@@ -28,7 +28,7 @@ describe('entry controller tests', () => {
     await mockUser.save();
     await mockJournal.save();
 
-    const entries = await EntryServices.getAllEntries(mockJournal.id);
+    const entries = await EntryServices.getAllEntriesInJournal(mockJournal.id);
 
     expect(entries.length).toBe(0);
   });
@@ -43,7 +43,7 @@ describe('entry controller tests', () => {
     await mockEntry1.save();
     await mockEntry2.save();
 
-    const entries = await EntryServices.getAllEntries(mockJournal.id);
+    const entries = await EntryServices.getAllEntriesInJournal(mockJournal.id);
 
     expect(entries.length).toBe(2);
   });
@@ -57,30 +57,11 @@ describe('entry controller tests', () => {
     await mockEntry1.save();
     await mockEntry2.save();
 
-    const entries1 = await EntryServices.getAllEntries(mockJournal1.id);
-    const entries2 = await EntryServices.getAllEntries(mockJournal2.id);
+    const entries1 = await EntryServices.getAllEntriesInJournal(mockJournal1.id);
+    const entries2 = await EntryServices.getAllEntriesInJournal(mockJournal2.id);
 
     expect(entries1.length).toBe(1);
     expect(entries2.length).toBe(1);
-  });
-
-  it('can create entry if journal exists', async () => {
-    const mockUser = new User({ fname: "test", lname: "test" });
-    const mockJournal = new Journal({ user: mockUser.id });
-    await mockJournal.save();
-
-    const sut = await EntryServices.canCreateEntry(mockJournal.id);
-
-    expect(sut).toBe(true);
-  });
-
-  it('cannot create entry if journal does not exist', async () => {
-    const mockUser = new User({ fname: "test", lname: "test" });
-    const mockJournal = new Journal({ user: mockUser.id });
-
-    const sut = await EntryServices.canCreateEntry(mockJournal.id);
-
-    expect(sut).toBe(false);
   });
 
   it('creates entries with valid journal id and content', async () => {


### PR DESCRIPTION
This PR refactors create operations in controllers/entry into separate functions and moves them to a new file /models/services/entry/entry.ts. It also adds unit tests for the create service functions.

This PR also resolves a build error in app.ts. Previously there was an error due to a mismatch between the Express.User type defined in our custom type declaration file, and the Express.User type defined in the passport library. To resolve this, I had the custom type extend our UserType in the type declaration file.