### PR TITLE
refactor: delete entry services refactoring

### DIFF
--- a/backend/src/models/services/entry/entry.ts
+++ b/backend/src/models/services/entry/entry.ts
@@ -5,11 +5,11 @@ import {
   EntryConversation,
 } from '../../index.js';
 import { UpdateChatRequestBody, UpdateEntryRequestBody } from '../../../controllers/entry/entry.js';
+import mongoose, { HydratedDocument } from 'mongoose';
 import { EntryAnalysisType } from '../../entry/entryAnalysis.js';
 import { EntryConversationType } from '../../entry/entryConversation.js';
 import { EntryType } from '../../entry/entry.js';
 import ExpressError from '../../../utils/ExpressError.js';
-import { HydratedDocument } from 'mongoose';
 
 /**
  * Return value of operations that create or update Entry
@@ -191,6 +191,41 @@ export async function updateEntryAnalysis(
 }
 
 /**
+ * Deletes Entry by ID and associated EntryConversation and EntryAnalysis.
+ * @param entryId id of entry to delete
+ */
+export async function deleteEntry(
+  entryId: string
+): Promise<void> {
+  // Start a session and transaction for atomicity
+  const session = await mongoose.startSession();
+  session.startTransaction();
+
+  try {
+    // Delete the entry
+    const response = await Entry.findByIdAndDelete(entryId, { session });
+
+    if (!response) {
+      throw new Error('Entry not found.');
+    }
+
+    // Delete associated documents
+    await EntryConversation.deleteMany({ entry: entryId }, { session });
+    await EntryAnalysis.deleteMany({ entry: entryId }, { session });
+
+    // Commit the transaction
+    await session.commitTransaction();
+  } catch (error) {
+    // If an error occurs, abort the transaction
+    await session.abortTransaction();
+    throw error;
+  } finally {
+    // End the session
+    session.endSession();
+  }
+}
+
+/**
  * Creates new EntryConversation for an Entry and populates with LLM response
  * 
  * This function throws errors to replicate how the original function
@@ -212,6 +247,7 @@ export async function createEntryConversation(
    * rejects empty messages, and that happens before hitting this function, but it's defensive
    */
   if (!messageData.messages || messageData.messages.length === 0) {
+    // TODO: try removing HTTP stuff from here
     throw new ExpressError('No message to get completion for.', 404);
   }
   // Get an entry with the analysis
@@ -322,6 +358,7 @@ async function _populateChatContent(
 async function _verifyEntryConversation(
   chatId: string
 ) {
+  // TODO: try removing HTTP stuff from here
   const conversation = await EntryConversation.findById(chatId);
   if (!conversation) {
     throw new ExpressError('Entry conversation not found.', 404);

--- a/backend/src/models/services/entry/entry.ts
+++ b/backend/src/models/services/entry/entry.ts
@@ -4,24 +4,12 @@ import {
   EntryAnalysis,
   EntryConversation,
 } from '../../index.js';
+import { UpdateChatRequestBody, UpdateEntryRequestBody } from '../../../controllers/entry/entry.js';
 import { EntryAnalysisType } from '../../entry/entryAnalysis.js';
 import { EntryConversationType } from '../../entry/entryConversation.js';
 import { EntryType } from '../../entry/entry.js';
 import ExpressError from '../../../utils/ExpressError.js';
 import { HydratedDocument } from 'mongoose';
-import { UpdateEntryRequestBody } from '../../../controllers/entry/entry.js';
-
-/**
- * TODO: consider moving this somewhere else. Might not be best fit here
- * given that it's for enforcing user input
- * Shape of data in request body when creating EntryConversation
- */
-interface MessageData {
-  messages: {
-    message_content: string,
-    llm_response: string
-  }[]
-}
 
 /**
  * Return value of operations that create or update Entry
@@ -202,6 +190,68 @@ export async function updateEntryAnalysis(
   };
 }
 
+/**
+ * Creates new EntryConversation for an Entry and populates with LLM response
+ * 
+ * This function throws errors to replicate how the original function
+ * handled them, which was to create a new error and call the error handler.
+ * The controller is responsible for catching errors and calling
+ * the error handler when using this function.
+ * @param entryId id of Entry to create EntryConversation for
+ * @param messageData user-submitted messages to create conversation for
+ * @param configId id of Config for LLM
+ * @returns new EntryConversation from messageData
+ */
+export async function createEntryConversation(
+  entryId: string,
+  configId: string,
+  messageData: UpdateChatRequestBody
+) {
+  /**
+   * I don't think this case will ever get used because joi validation
+   * rejects empty messages, and that happens before hitting this function, but it's defensive
+   */
+  if (!messageData.messages || messageData.messages.length === 0) {
+    throw new ExpressError('No message to get completion for.', 404);
+  }
+  // Get an entry with the analysis
+  const { entry, entryAnalysis } = await _verifyEntry(entryId);
+  
+  const newConversation = new EntryConversation({
+    entry: entryId,
+    messages: messageData.messages,
+  });
+
+  // Associate the conversation with the entry
+  entry.conversation = newConversation.id;
+  
+  // TODO: try to use _populateChatContent. Can't currently because this doesn't append; it modifies in place
+  const llmResponse = await CdGptServices.getChatContent(
+    configId,
+    entryAnalysis.id,
+    messageData.messages[0].message_content
+  );
+  
+  if (llmResponse) {
+    // messages defined because messageData.mesages defined
+    newConversation.messages![0].llm_response = llmResponse;
+  }
+  await newConversation.save();
+  await entry.save();
+
+  return newConversation;
+}
+
+export async function updateEntryConversation(
+  chatId: string,
+  configId: string,
+  messageData: UpdateChatRequestBody
+) {
+  const { conversation, analysis } = await _verifyEntryConversation(chatId);
+
+  return await _populateChatContent(configId, analysis, messageData, conversation);
+}
+
 async function _verifyEntry(entryId: string) {
   const entry = await getEntryById(entryId);
   if (!entry) {
@@ -247,60 +297,41 @@ async function _updateEntry(
   return updateEntryResult;
 }
 
-/**
- * TODO: continue breaking up this function
- * Creates new EntryConversation for an Entry and populates with LLM response
- * 
- * This function throws errors to replicate how the original function
- * handled them, which was to create a new error and call the error handler.
- * The controller is responsible for catching errors and calling
- * the error handler when using this function.
- * @param entryId id of Entry to create EntryConversation for
- * @param messageData user-submitted messages to create conversation for
- * @param configId id of Config for LLM
- * @returns new EntryConversation from messageData
- */
-export async function createEntryConversation(
-  entryId: string,
+async function _populateChatContent(
   configId: string,
-  messageData: MessageData
+  analysis: HydratedDocument<EntryAnalysisType>,
+  messageData: UpdateChatRequestBody,
+  conversation: HydratedDocument<EntryConversationType>
 ) {
-  // Get an entry with the analysis
-  const entry = await Entry.findById(entryId);
-  if (!entry) {
-    throw new ExpressError('Entry not found.', 404);
-  }
-  if (!entry.analysis) {
-    throw new ExpressError('Entry analysis not found.', 404);
-  }
-  
-  const newConversation = new EntryConversation({
-    entry: entryId,
-    ...messageData,
-  });
-  /**
-   * I don't think this case will ever get used because joi validation
-   * rejects empty messages, and that happens before hitting this function, but it's defensive
-   */
-  if (!newConversation.messages || newConversation.messages.length === 0) {
-    throw new ExpressError('No message to get completion for.', 404);
-  }
-  
-  // Associate the conversation with the entry
-  entry.conversation = newConversation.id;
-  await entry.save();
-  
   const llmResponse = await CdGptServices.getChatContent(
     configId,
-    entry.analysis.toString(),
-    messageData.messages[0].message_content
+    analysis.id,
+    messageData.messages[0].message_content,
+    conversation.messages
   );
-  
-  // If the chat is not empty, update the llm_response
-  if (llmResponse) {
-    newConversation.messages[0].llm_response = llmResponse;
-  }
-  await newConversation.save();
 
-  return newConversation;
+  // If the chat is not empty, update the llm_response
+  if (llmResponse) { // TODO: this will drop chats that fail to get llm response. Is that fine?
+    messageData.messages[0].llm_response = llmResponse;
+    conversation.messages?.push(messageData.messages[0]);
+    await conversation.save();
+  }
+  return conversation;
+}
+
+async function _verifyEntryConversation(
+  chatId: string
+) {
+  const conversation = await EntryConversation.findById(chatId);
+  if (!conversation) {
+    throw new ExpressError('Entry conversation not found.', 404);
+  }
+  if (!conversation.messages) {
+    throw new ExpressError('Entry conversation messages not found.', 404);
+  }
+  const analysis = await EntryAnalysis.findOne({ entry: conversation.entry });
+  if (!analysis) {
+    throw new ExpressError('Entry analysis not found.', 404);
+  }
+  return { conversation, analysis };
 }

--- a/backend/src/models/services/entry/entry.ts
+++ b/backend/src/models/services/entry/entry.ts
@@ -12,9 +12,9 @@ import { HydratedDocument } from 'mongoose';
 import { UpdateEntryRequestBody } from '../../../controllers/entry/entry.js';
 
 /**
- * Shape of data in request body when creating EntryConversation
  * TODO: consider moving this somewhere else. Might not be best fit here
  * given that it's for enforcing user input
+ * Shape of data in request body when creating EntryConversation
  */
 interface MessageData {
   messages: {
@@ -173,23 +173,45 @@ export async function updateEntry(
   entryData: UpdateEntryRequestBody,
 ) {
   const { title: entryTitle, content: entryContent } = entryData;
-  const updatedEntry = await getEntryById(entryId);
-  if (!updatedEntry) {
+  const { entry, entryAnalysis } = await _verifyEntry(entryId);
+
+  if (entryContent) {
+    entry.content = entryContent;
+    return await _updateEntry(entry, entryAnalysis, configId);
+  } else if (entryTitle) {
+    entry.title = entryTitle;
+    await entry.save();
+  }
+  return { entry: entry };
+}
+
+/**
+ * 
+ * @param entryId 
+ * @param configId 
+ * @returns 
+ */
+export async function updateEntryAnalysis(
+  entryId: string,
+  configId: string,
+) {
+  const { entry, entryAnalysis } = await _verifyEntry(entryId);
+  return {
+    ...await _updateEntry(entry, entryAnalysis, configId),
+    entryAnalysis: entryAnalysis 
+  };
+}
+
+async function _verifyEntry(entryId: string) {
+  const entry = await getEntryById(entryId);
+  if (!entry) {
     throw new Error('Entry not found.');
   }
-  const oldAnalysis = await getEntryAnalysisById(entryId);
-  if (!oldAnalysis) {
+  const entryAnalysis = await getEntryAnalysisById(entryId);
+  if (!entryAnalysis) {
     throw new Error('Entry analysis not found.');
   }
-  
-  if (entryContent) {
-    updatedEntry.content = entryContent;
-    return await _updateEntry(updatedEntry, oldAnalysis, configId);
-  } else if (entryTitle) {
-    updatedEntry.title = entryTitle;
-    await updatedEntry.save();
-  }
-  return { entry: updatedEntry };
+  return { entry, entryAnalysis };
 }
 
 async function _updateEntry(
@@ -246,7 +268,7 @@ export async function createEntryConversation(
   // Get an entry with the analysis
   const entry = await Entry.findById(entryId);
   if (!entry) {
-    throw new ExpressError('Entry not found.', 404); // TODO: reconsider having HTTP codes in domain logic
+    throw new ExpressError('Entry not found.', 404);
   }
   if (!entry.analysis) {
     throw new ExpressError('Entry analysis not found.', 404);

--- a/backend/tests/db.test.ts
+++ b/backend/tests/db.test.ts
@@ -1,6 +1,3 @@
-/* eslint-disable jest/no-disabled-tests */
-/* eslint-disable sort-imports */
-
 import 'dotenv/config';
 
 import connectDB from '../src/db.js';
@@ -27,8 +24,9 @@ describe('connectDB', () => {
     process.env = originalEnv;
   });
 
-  it.skip('should connect to MongoDB Atlas in production environment', async () => {
+  it('should connect to MongoDB Atlas in production environment', async () => {
     process.env.NODE_ENV = 'production';
+    process.env.ATLAS_URI = 'testuri';
     const atlasUri = process.env.ATLAS_URI;
 
     await connectDB('testdb');

--- a/backend/tests/jest.setup.cjs
+++ b/backend/tests/jest.setup.cjs
@@ -1,13 +1,13 @@
 require('dotenv').config();
-const MongoMemoryServer = require('mongodb-memory-server').MongoMemoryServer;
+const { MongoMemoryReplSet } = require('mongodb-memory-server');
 const mongoose = require('mongoose');
 
 module.exports = async () => {
   console.log('\nSetup: config mongodb for testing...');
   // https://typegoose.github.io/mongodb-memory-server/docs/guides/integration-examples/test-runners/
-  const instance = await MongoMemoryServer.create();
-  const uri = instance.getUri();
-  global.__MONGOINSTANCE = instance;
+  const replSet = await MongoMemoryReplSet.create({ replSet: { count: 3 } });
+  const uri = replSet.getUri();
+  global.__MONGOREPLSET = replSet;
   process.env.MONGO_URI = uri.slice(0, uri.lastIndexOf('/'));
 
   // Make sure the database is empty before running tests.

--- a/backend/tests/jest.teardown.cjs
+++ b/backend/tests/jest.teardown.cjs
@@ -3,6 +3,6 @@ require('dotenv').config();
 module.exports = async () => {
   console.log('Teardown: Dropping test database...');
   // https://typegoose.github.io/mongodb-memory-server/docs/guides/integration-examples/test-runners/
-  const instance = global.__MONGOINSTANCE;
-  await instance.stop();
+  const replSet = global.__MONGOREPLSET;
+  await replSet.stop();
 };

--- a/backend/tests/models/services/entry/entry.test.ts
+++ b/backend/tests/models/services/entry/entry.test.ts
@@ -6,6 +6,9 @@ import * as CdGptServices from '../../../../src/models/services/CdGpt.js';
 import * as EntryServices from '../../../../src/models/services/entry/entry.js';
 import { Config, Entry, EntryAnalysis, EntryConversation, Journal, User } from '../../../../src/models/index.js';
 import mongoose, { HydratedDocument } from 'mongoose';
+import { EntryAnalysisType } from '../../../../src/models/entry/entryAnalysis.js';
+import { EntryConversationType } from '../../../../src/models/entry/entryConversation.js';
+import { EntryType } from '../../../../src/models/entry/entry.js';
 import { JournalType } from '../../../../src/models/journal.js';
 import { UserType } from '../../../../src/models/user.js';
 import connectDB from '../../../../src/db.js';
@@ -471,6 +474,32 @@ describe('Entry service tests', () => {
       expect(sut.messages![0].message_content).toBe('message_content');
       expect(sut.messages![0].llm_response).toBe('test chat llm response');
     });
-    
+  });
+
+  describe('Delete Entry tests', () => {
+    let mockEntry: HydratedDocument<EntryType>;
+    let mockAnalysis: HydratedDocument<EntryAnalysisType>;
+    let mockChat: HydratedDocument<EntryConversationType>;
+
+    beforeEach(async () => {
+      mockEntry = new Entry({ journal: mockJournal.id, content: 'mock content' });
+      mockAnalysis = new EntryAnalysis({ entry: mockEntry, analysis_content: 'test content', created_at: new Date(0), updated_at: new Date(0) });
+      mockChat = new EntryConversation({ entry: mockEntry, messages: [] });
+      await mockChat.save();
+      await mockAnalysis.save();
+      await mockEntry.save();
+    });
+
+    it('deletes Entry, EntryAnalysis, and EntryConversation by ID', async () => {
+      await EntryServices.deleteEntry(mockEntry.id);
+
+      await expect(Entry.findById(mockEntry.id)).resolves.toBeNull();
+      await expect(EntryAnalysis.findById(mockAnalysis.id)).resolves.toBeNull();
+      await expect(EntryConversation.findById(mockChat.id)).resolves.toBeNull();
+    });
+
+    it('aborts delete transcation on error', async () => {
+      expect(false).toBe(true);
+    });
   });
 });

--- a/backend/tests/models/services/entry/entry.test.ts
+++ b/backend/tests/models/services/entry/entry.test.ts
@@ -82,13 +82,13 @@ describe('Entry service tests', () => {
 
       const sut = await EntryServices.getPopulatedEntry(mockEntry.id);
 
-      expect(sut?.id).toBe(mockEntry.id);
-      expect(sut?.analysis.entry.toString()).toBe(mockEntry.id);
-      expect(sut?.analysis.analysis_content).toBe('test content');
-      expect(sut?.analysis.created_at).toBeDefined();
-      expect(sut?.analysis.updated_at).toBeDefined();
-      expect(sut?.conversation.entry.toString()).toBe(mockEntry.id);
-      expect(sut?.conversation.messages).toBeDefined();
+      expect(sut!.id).toBe(mockEntry.id);
+      expect(sut!.analysis.entry.toString()).toBe(mockEntry.id);
+      expect(sut!.analysis.analysis_content).toBe('test content');
+      expect(sut!.analysis.created_at).toBeDefined();
+      expect(sut!.analysis.updated_at).toBeDefined();
+      expect(sut!.conversation.entry.toString()).toBe(mockEntry.id);
+      expect(sut!.conversation.messages).toBeDefined();
     });
 
     it('gets EntryAnalysis by entryId entry populated with Entry', async () => {
@@ -100,9 +100,9 @@ describe('Entry service tests', () => {
 
       const sut = await EntryServices.getPopluatedEntryAnalysis(mockEntry.id);
 
-      expect(sut?.id).toBe(mockAnalysis.id);
-      expect(sut?.entry.content).toBe('mock content');
-      expect(sut?.entry.journal.toString()).toBe(mockJournal.id);
+      expect(sut!.id).toBe(mockAnalysis.id);
+      expect(sut!.entry.content).toBe('mock content');
+      expect(sut!.entry.journal.toString()).toBe(mockJournal.id);
     });
 
     it('returns null on error when getting populated EntryAnalysis', async () => {
@@ -119,7 +119,7 @@ describe('Entry service tests', () => {
 
       const sut = await EntryServices.getEntryConversation(mockEntry.id);
 
-      expect(sut?.id).toBe(mockConversation.id);
+      expect(sut!.id).toBe(mockConversation.id);
     });
 
     it('returns null on error when getting EntryConversation', async () => {
@@ -145,8 +145,8 @@ describe('Entry service tests', () => {
       expect(sut.journal.toString()).toBe(mockJournal.id);
       expect(sut.content).toBe('mock content');
       expect(sut.tags).toStrictEqual([]);
-      expect(sut.analysis?.toString()).toBe(testAnalysis?.id);
-      expect(testAnalysis?.analysis_content).toBe('Analysis not available');
+      expect(sut.analysis!.toString()).toBe(testAnalysis!.id);
+      expect(testAnalysis!.analysis_content).toBe('Analysis not available');
     });
 
     it('creates Entry with valid journal id, config id, and content with analysis returned', async () => {
@@ -171,8 +171,8 @@ describe('Entry service tests', () => {
       expect(sut.mood).toBe(mockAnalysisContent.mood);
       expect(sut.content).toBe('mock content');
       expect(sut.tags).toStrictEqual(mockAnalysisContent.tags);
-      expect(sut.analysis?.toString()).toBe(testAnalysis?.id);
-      expect(testAnalysis?.analysis_content).toBe(mockAnalysisContent.analysis_content);
+      expect(sut.analysis!.toString()).toBe(testAnalysis!.id);
+      expect(testAnalysis!.analysis_content).toBe(mockAnalysisContent.analysis_content);
     });
 
     it('returns error message when getting analysis content throws error', async () => {
@@ -192,8 +192,8 @@ describe('Entry service tests', () => {
       expect(sut.mood).toBeUndefined();
       expect(sut.content).toBe('mock content');
       expect(sut.tags).toStrictEqual([]);
-      expect(sut.analysis?.toString()).toBe(testAnalysis?.id);
-      expect(testAnalysis?.analysis_content).toBe('Analysis not available');
+      expect(sut.analysis!.toString()).toBe(testAnalysis!.id);
+      expect(testAnalysis!.analysis_content).toBe('Analysis not available');
     });
 
     it('creates and saves EntryConversation with valid input', async () => {
@@ -333,8 +333,8 @@ describe('Entry service tests', () => {
       expect(sut.journal.toString()).toBe(mockJournal.id);
       expect(sut.content).toBe('mock content');
       expect(sut.tags).toStrictEqual([]);
-      expect(sut.analysis?.toString()).toBe(testAnalysis?.id);
-      expect(testAnalysis?.analysis_content).toBe('Analysis not available');
+      expect(sut.analysis!.toString()).toBe(testAnalysis!.id);
+      expect(testAnalysis!.analysis_content).toBe('Analysis not available');
     });
   
     it('updates Entry with valid journal id, config id, and content with analysis returned', async () => {
@@ -364,8 +364,8 @@ describe('Entry service tests', () => {
       expect(sut.mood).toBe(mockAnalysisContent.mood);
       expect(sut.content).toBe('mock content');
       expect(sut.tags).toStrictEqual(mockAnalysisContent.tags);
-      expect(sut.analysis?.toString()).toBe(testAnalysis?.id);
-      expect(testAnalysis?.analysis_content).toBe(mockAnalysisContent.analysis_content);
+      expect(sut.analysis!.toString()).toBe(testAnalysis!.id);
+      expect(testAnalysis!.analysis_content).toBe(mockAnalysisContent.analysis_content);
     });
   
     it('returns error message when getting analysis content throws error', async () => {
@@ -389,8 +389,8 @@ describe('Entry service tests', () => {
       expect(sut.mood).toBeUndefined();
       expect(sut.content).toBe('mock content');
       expect(sut.tags).toStrictEqual([]);
-      expect(sut.analysis?.toString()).toBe(testAnalysis?.id);
-      expect(testAnalysis?.analysis_content).toBe('Analysis not available');
+      expect(sut.analysis!.toString()).toBe(testAnalysis!.id);
+      expect(testAnalysis!.analysis_content).toBe('Analysis not available');
     });
 
     it('updates title when content is empty', async () => {
@@ -412,8 +412,8 @@ describe('Entry service tests', () => {
       expect(sut.mood).toBeUndefined();
       expect(sut.content).toBe('mock content');
       expect(sut.tags).toStrictEqual([]);
-      expect(sut.analysis?.toString()).toBe(testAnalysis?.id);
-      expect(testAnalysis?.analysis_content).toBe('Analysis not available');
+      expect(sut.analysis!.toString()).toBe(testAnalysis!.id);
+      expect(testAnalysis!.analysis_content).toBe('Analysis not available');
     });
   });
 
@@ -440,9 +440,9 @@ describe('Entry service tests', () => {
       expect(sut.journal.toString()).toBe(mockJournal.id);
       expect(sut.content).toBe('mock content');
       expect(sut.tags).toStrictEqual(updateContent.tags);
-      expect(sut.analysis?.toString()).toBe(testAnalysis?.id);
+      expect(sut.analysis!.toString()).toBe(testAnalysis!.id);
+      expect(testAnalysis!.analysis_content).toBe(updateContent.analysis_content);
       expect(sut.mood).toBe(updateContent.mood);
-      expect(testAnalysis?.analysis_content).toBe(updateContent.analysis_content);
     });
   });
 

--- a/backend/tests/models/services/entry/entry.test.ts
+++ b/backend/tests/models/services/entry/entry.test.ts
@@ -33,282 +33,285 @@ describe('Entry service tests', () => {
     await mongoose.disconnect();
   });
 
-  it('gets no entries in an empty journal', async () => {
-    const entries = await EntryServices.getAllEntriesInJournal(mockJournal.id);
+  describe('Get Entry service operation tests', () => {
+    it('gets no entries in an empty journal', async () => {
+      const entries = await EntryServices.getAllEntriesInJournal(mockJournal.id);
 
-    expect(entries).toHaveLength(0);
-  });
+      expect(entries).toHaveLength(0);
+    });
 
-  it('returns empty list on error when getting all entries', async () => {
-    const entries = await EntryServices.getAllEntriesInJournal('bad id');
+    it('returns empty list on error when getting all entries', async () => {
+      const entries = await EntryServices.getAllEntriesInJournal('bad id');
 
-    expect(entries).toHaveLength(0);
-  });
+      expect(entries).toHaveLength(0);
+    });
 
-  it('gets all entries in a journal', async () => {
-    const mockEntry1 = new Entry({ journal: mockJournal.id, content: 'mock content' });
-    const mockEntry2 = new Entry({ journal: mockJournal.id, content: 'mock content' });
-    await mockEntry1.save();
-    await mockEntry2.save();
+    it('gets all entries in a journal', async () => {
+      const mockEntry1 = new Entry({ journal: mockJournal.id, content: 'mock content' });
+      const mockEntry2 = new Entry({ journal: mockJournal.id, content: 'mock content' });
+      await mockEntry1.save();
+      await mockEntry2.save();
 
-    const entries = await EntryServices.getAllEntriesInJournal(mockJournal.id);
+      const entries = await EntryServices.getAllEntriesInJournal(mockJournal.id);
 
-    expect(entries).toHaveLength(2);
-  });
+      expect(entries).toHaveLength(2);
+    });
 
-  it('gets entries from only one journal', async () => {
-    const mockJournal2 = new Journal({ user: mockUser.id });
-    const mockEntry1 = new Entry({ journal: mockJournal.id, content: 'mock content' });
-    const mockEntry2 = new Entry({ journal: mockJournal2.id, content: 'mock content' });
-    await mockEntry1.save();
-    await mockEntry2.save();
+    it('gets entries from only one journal', async () => {
+      const mockJournal2 = new Journal({ user: mockUser.id });
+      const mockEntry1 = new Entry({ journal: mockJournal.id, content: 'mock content' });
+      const mockEntry2 = new Entry({ journal: mockJournal2.id, content: 'mock content' });
+      await mockEntry1.save();
+      await mockEntry2.save();
 
-    const entries1 = await EntryServices.getAllEntriesInJournal(mockJournal.id);
-    const entries2 = await EntryServices.getAllEntriesInJournal(mockJournal2.id);
+      const entries1 = await EntryServices.getAllEntriesInJournal(mockJournal.id);
+      const entries2 = await EntryServices.getAllEntriesInJournal(mockJournal2.id);
 
-    expect(entries1).toHaveLength(1);
-    expect(entries2).toHaveLength(1);
-  });
+      expect(entries1).toHaveLength(1);
+      expect(entries2).toHaveLength(1);
+    });
 
-  it('gets Entry by entryId populated with EntryAnalysis and EntryConversation', async () => {
-    const mockEntry = new Entry({ journal: mockJournal.id, content: 'mock content' });
-    const mockAnalysis = new EntryAnalysis({ entry: mockEntry, analysis_content: 'test content', created_at: new Date(0), updated_at: new Date(0) });
-    const mockConversation = new EntryConversation({ entry: mockEntry, messages: [] });
-    mockEntry.analysis = mockAnalysis.id;
-    mockEntry.conversation = mockConversation.id;
-    await mockAnalysis.save();
-    await mockConversation.save();
-    await mockEntry.save();
+    it('gets Entry by entryId populated with EntryAnalysis and EntryConversation', async () => {
+      const mockEntry = new Entry({ journal: mockJournal.id, content: 'mock content' });
+      const mockAnalysis = new EntryAnalysis({ entry: mockEntry, analysis_content: 'test content', created_at: new Date(0), updated_at: new Date(0) });
+      const mockConversation = new EntryConversation({ entry: mockEntry, messages: [] });
+      mockEntry.analysis = mockAnalysis.id;
+      mockEntry.conversation = mockConversation.id;
+      await mockAnalysis.save();
+      await mockConversation.save();
+      await mockEntry.save();
 
-    const sut = await EntryServices.getPopulatedEntry(mockEntry.id);
+      const sut = await EntryServices.getPopulatedEntry(mockEntry.id);
 
-    expect(sut?.id).toBe(mockEntry.id);
-    expect(sut?.analysis.entry.toString()).toBe(mockEntry.id);
-    expect(sut?.analysis.analysis_content).toBe('test content');
-    expect(sut?.analysis.created_at).toBeDefined();
-    expect(sut?.analysis.updated_at).toBeDefined();
-    expect(sut?.conversation.entry.toString()).toBe(mockEntry.id);
-    expect(sut?.conversation.messages).toBeDefined();
-  });
+      expect(sut?.id).toBe(mockEntry.id);
+      expect(sut?.analysis.entry.toString()).toBe(mockEntry.id);
+      expect(sut?.analysis.analysis_content).toBe('test content');
+      expect(sut?.analysis.created_at).toBeDefined();
+      expect(sut?.analysis.updated_at).toBeDefined();
+      expect(sut?.conversation.entry.toString()).toBe(mockEntry.id);
+      expect(sut?.conversation.messages).toBeDefined();
+    });
 
-  it('gets EntryAnalysis by entryId entry populated with Entry', async () => {
-    const mockEntry = new Entry({ journal: mockJournal.id, content: 'mock content' });
-    const mockAnalysis = new EntryAnalysis({ entry: mockEntry, analysis_content: 'test content', created_at: new Date(0), updated_at: new Date(0) });
-    mockEntry.analysis = mockAnalysis.id;
-    await mockAnalysis.save();
-    await mockEntry.save();
+    it('gets EntryAnalysis by entryId entry populated with Entry', async () => {
+      const mockEntry = new Entry({ journal: mockJournal.id, content: 'mock content' });
+      const mockAnalysis = new EntryAnalysis({ entry: mockEntry, analysis_content: 'test content', created_at: new Date(0), updated_at: new Date(0) });
+      mockEntry.analysis = mockAnalysis.id;
+      await mockAnalysis.save();
+      await mockEntry.save();
 
-    const sut = await EntryServices.getPopluatedEntryAnalysis(mockEntry.id);
+      const sut = await EntryServices.getPopluatedEntryAnalysis(mockEntry.id);
 
-    expect(sut?.id).toBe(mockAnalysis.id);
-    expect(sut?.entry.content).toBe('mock content');
-    expect(sut?.entry.journal.toString()).toBe(mockJournal.id);
-  });
+      expect(sut?.id).toBe(mockAnalysis.id);
+      expect(sut?.entry.content).toBe('mock content');
+      expect(sut?.entry.journal.toString()).toBe(mockJournal.id);
+    });
 
-  it('returns null on error when getting populated EntryAnalysis', async () => {
-    const sut = await EntryServices.getPopluatedEntryAnalysis('bad id');
+    it('returns null on error when getting populated EntryAnalysis', async () => {
+      const sut = await EntryServices.getPopluatedEntryAnalysis('bad id');
     
-    expect(sut).toBeNull();
-  });
+      expect(sut).toBeNull();
+    });
 
-  it('gets EntryConversation by entryId', async () => {
-    const mockEntry = new Entry({ journal: mockJournal.id, content: 'mock content' });
-    const mockConversation = new EntryConversation({ entry: mockEntry, messages: [] });
-    await mockConversation.save();
-    await mockEntry.save();
+    it('gets EntryConversation by entryId', async () => {
+      const mockEntry = new Entry({ journal: mockJournal.id, content: 'mock content' });
+      const mockConversation = new EntryConversation({ entry: mockEntry, messages: [] });
+      await mockConversation.save();
+      await mockEntry.save();
 
-    const sut = await EntryServices.getEntryConversation(mockEntry.id);
+      const sut = await EntryServices.getEntryConversation(mockEntry.id);
 
-    expect(sut?.id).toBe(mockConversation.id);
-  });
+      expect(sut?.id).toBe(mockConversation.id);
+    });
 
-  it('returns null on error when getting EntryConversation', async () => {
-    const sut = await EntryServices.getEntryConversation('bad id');
+    it('returns null on error when getting EntryConversation', async () => {
+      const sut = await EntryServices.getEntryConversation('bad id');
     
-    expect(sut).toBeNull();
+      expect(sut).toBeNull();
+    });
   });
 
-  it('creates Entry with valid journal id, config id, and content', async () => {
-    const mockEntryContent = {
-      content: 'mock content',
-    };
-    const mockConfig = await Config.create({ model: {} });
-    mockedCdGptServices.getAnalysisContent.mockResolvedValue(undefined);
+  describe('Create operation Entry service tests', () => {
+    it('creates Entry with valid journal id, config id, and content', async () => {
+      const mockEntryContent = {
+        content: 'mock content',
+      };
+      const mockConfig = await Config.create({ model: {} });
+      mockedCdGptServices.getAnalysisContent.mockResolvedValue(undefined);
 
-    const { errMessage, entry: sut } = await EntryServices.createEntry(mockJournal.id, mockConfig.id, mockEntryContent);
-    const testAnalysis = await EntryAnalysis.findById(sut.analysis);
+      const { errMessage, entry: sut } = await EntryServices.createEntry(mockJournal.id, mockConfig.id, mockEntryContent);
+      const testAnalysis = await EntryAnalysis.findById(sut.analysis);
 
-    expect(errMessage).toBeUndefined();
-    expect(sut.title).toBe('Untitled');
-    expect(sut.journal.toString()).toBe(mockJournal.id);
-    expect(sut.content).toBe('mock content');
-    expect(sut.tags).toStrictEqual([]);
-    expect(sut.analysis?.toString()).toBe(testAnalysis?.id);
-    expect(testAnalysis?.analysis_content).toBe('Analysis not available');
-  });
+      expect(errMessage).toBeUndefined();
+      expect(sut.title).toBe('Untitled');
+      expect(sut.journal.toString()).toBe(mockJournal.id);
+      expect(sut.content).toBe('mock content');
+      expect(sut.tags).toStrictEqual([]);
+      expect(sut.analysis?.toString()).toBe(testAnalysis?.id);
+      expect(testAnalysis?.analysis_content).toBe('Analysis not available');
+    });
 
-  it('creates Entry with valid journal id, config id, and content with analysis returned', async () => {
-    const mockEntryContent = {
-      content: 'mock content',
-    };
-    const mockConfig = await Config.create({ model: {} });
-    const mockAnalysisContent = {
-      title: 'Mock Title',
-      mood: 'mock mood',
-      tags: ['test', 'mock'],
-      analysis_content: 'mock analysis content',
-    };
-    mockedCdGptServices.getAnalysisContent.mockResolvedValue(mockAnalysisContent);
+    it('creates Entry with valid journal id, config id, and content with analysis returned', async () => {
+      const mockEntryContent = {
+        content: 'mock content',
+      };
+      const mockConfig = await Config.create({ model: {} });
+      const mockAnalysisContent = {
+        title: 'Mock Title',
+        mood: 'mock mood',
+        tags: ['test', 'mock'],
+        analysis_content: 'mock analysis content',
+      };
+      mockedCdGptServices.getAnalysisContent.mockResolvedValue(mockAnalysisContent);
 
-    const { errMessage, entry: sut } = await EntryServices.createEntry(mockJournal.id, mockConfig.id, mockEntryContent);
-    const testAnalysis = await EntryAnalysis.findById(sut.analysis);
+      const { errMessage, entry: sut } = await EntryServices.createEntry(mockJournal.id, mockConfig.id, mockEntryContent);
+      const testAnalysis = await EntryAnalysis.findById(sut.analysis);
 
-    expect(errMessage).toBeUndefined();
-    expect(sut.title).toBe(mockAnalysisContent.title);
-    expect(sut.journal.toString()).toBe(mockJournal.id);
-    expect(sut.mood).toBe(mockAnalysisContent.mood);
-    expect(sut.content).toBe('mock content');
-    expect(sut.tags).toStrictEqual(mockAnalysisContent.tags);
-    expect(sut.analysis?.toString()).toBe(testAnalysis?.id);
-    expect(testAnalysis?.analysis_content).toBe(mockAnalysisContent.analysis_content);
-  });
+      expect(errMessage).toBeUndefined();
+      expect(sut.title).toBe(mockAnalysisContent.title);
+      expect(sut.journal.toString()).toBe(mockJournal.id);
+      expect(sut.mood).toBe(mockAnalysisContent.mood);
+      expect(sut.content).toBe('mock content');
+      expect(sut.tags).toStrictEqual(mockAnalysisContent.tags);
+      expect(sut.analysis?.toString()).toBe(testAnalysis?.id);
+      expect(testAnalysis?.analysis_content).toBe(mockAnalysisContent.analysis_content);
+    });
 
-  it('returns error message when getting analysis content throws error', async () => {
-    const mockEntryContent = {
-      journal: mockJournal.id,
-      content: 'mock content',
-    };
-    const mockConfig = await Config.create({ model: {} });
-    mockedCdGptServices.getAnalysisContent.mockRejectedValue(new Error('test error message'));
+    it('returns error message when getting analysis content throws error', async () => {
+      const mockEntryContent = {
+        journal: mockJournal.id,
+        content: 'mock content',
+      };
+      const mockConfig = await Config.create({ model: {} });
+      mockedCdGptServices.getAnalysisContent.mockRejectedValue(new Error('test error message'));
 
-    const { errMessage, entry: sut } = await EntryServices.createEntry(mockJournal.id, mockConfig.id, mockEntryContent);
-    const testAnalysis = await EntryAnalysis.findById(sut.analysis);
+      const { errMessage, entry: sut } = await EntryServices.createEntry(mockJournal.id, mockConfig.id, mockEntryContent);
+      const testAnalysis = await EntryAnalysis.findById(sut.analysis);
 
-    expect(errMessage).toBe('test error message');
-    expect(sut.title).toBe('Untitled');
-    expect(sut.journal.toString()).toBe(mockJournal.id);
-    expect(sut.mood).toBeUndefined();
-    expect(sut.content).toBe('mock content');
-    expect(sut.tags).toStrictEqual([]);
-    expect(sut.analysis?.toString()).toBe(testAnalysis?.id);
-    expect(testAnalysis?.analysis_content).toBe('Analysis not available');
-  });
+      expect(errMessage).toBe('test error message');
+      expect(sut.title).toBe('Untitled');
+      expect(sut.journal.toString()).toBe(mockJournal.id);
+      expect(sut.mood).toBeUndefined();
+      expect(sut.content).toBe('mock content');
+      expect(sut.tags).toStrictEqual([]);
+      expect(sut.analysis?.toString()).toBe(testAnalysis?.id);
+      expect(testAnalysis?.analysis_content).toBe('Analysis not available');
+    });
 
-  it('creates and saves EntryConversation with valid input', async () => {
-    const mockEntry = new Entry({ journal: mockJournal.id, content: 'mock content' });
-    const mockEntryAnalysis = await EntryAnalysis.create({ entry: mockEntry.id });
-    mockEntry.analysis = mockEntryAnalysis.id;
-    await mockEntry.save();
-    const mockConfig = await Config.create({ model: {} });
-    const mockMessageData = {
-      messages: [
-        {
-          message_content: 'test message',
-          llm_response: 'mock llm response'
-        },
-      ]
-    };
-    const mockLlmContent = 'mock llm chat response';
-    jest.spyOn(CdGptServices, 'getChatContent').mockResolvedValue(mockLlmContent);
+    it('creates and saves EntryConversation with valid input', async () => {
+      const mockEntry = new Entry({ journal: mockJournal.id, content: 'mock content' });
+      const mockEntryAnalysis = await EntryAnalysis.create({ entry: mockEntry.id });
+      mockEntry.analysis = mockEntryAnalysis.id;
+      await mockEntry.save();
+      const mockConfig = await Config.create({ model: {} });
+      const mockMessageData = {
+        messages: [
+          {
+            message_content: 'test message',
+            llm_response: 'mock llm response'
+          },
+        ]
+      };
+      const mockLlmContent = 'mock llm chat response';
+      jest.spyOn(CdGptServices, 'getChatContent').mockResolvedValue(mockLlmContent);
     
-    const sut = await EntryServices.createEntryConversation(
-      mockEntry.id,
-      mockConfig.id,
-      mockMessageData
-    );
+      const sut = await EntryServices.createEntryConversation(
+        mockEntry.id,
+        mockConfig.id,
+        mockMessageData
+      );
 
-    expect(sut.entry.toString()).toBe(mockEntry.id);
-    expect(sut.messages?.length).toBe(1);
-    expect((sut.messages as ChatMessage[])[0].message_content).toBe(mockMessageData.messages[0].message_content);
-    expect((sut.messages as ChatMessage[])[0].llm_response).toBe(mockLlmContent);
-  });
+      expect(sut.entry.toString()).toBe(mockEntry.id);
+      expect(sut.messages?.length).toBe(1);
+      expect((sut.messages as ChatMessage[])[0].message_content).toBe(mockMessageData.messages[0].message_content);
+      expect((sut.messages as ChatMessage[])[0].llm_response).toBe(mockLlmContent);
+    });
 
-  it('throws error on missing entry when creating EntryConversation', async () => {
-    const nonexistentEntry = new Entry({ journal: mockJournal.id, content: 'mock content' });
-    const mockConfig = new Config({ model: {} });
-    const mockMessageData = {
-      messages: [
-        {
-          message_content: 'test message',
-          llm_response: 'mock llm response'
-        },
-      ]
-    };
+    it('throws error on missing entry when creating EntryConversation', async () => {
+      const nonexistentEntry = new Entry({ journal: mockJournal.id, content: 'mock content' });
+      const mockConfig = new Config({ model: {} });
+      const mockMessageData = {
+        messages: [
+          {
+            message_content: 'test message',
+            llm_response: 'mock llm response'
+          },
+        ]
+      };
     
-    await expect(EntryServices.createEntryConversation(
-      nonexistentEntry.id,
-      mockConfig.id,
-      mockMessageData
-    )).rejects.toThrow('Entry not found.');
-  });
+      await expect(EntryServices.createEntryConversation(
+        nonexistentEntry.id,
+        mockConfig.id,
+        mockMessageData
+      )).rejects.toThrow('Entry not found.');
+    });
 
-  it('throws error on missing entry.analysis when creating EntryConversation', async () => {
-    const mockEntry = new Entry({ journal: mockJournal.id, content: 'mock content' });
-    await mockEntry.save();
-    const mockConfig = new Config({ model: {} });
-    const mockMessageData = {
-      messages: [
-        {
-          message_content: 'test message',
-          llm_response: 'mock llm response'
-        },
-      ]
-    };
+    it('throws error on missing entry.analysis when creating EntryConversation', async () => {
+      const mockEntry = new Entry({ journal: mockJournal.id, content: 'mock content' });
+      await mockEntry.save();
+      const mockConfig = new Config({ model: {} });
+      const mockMessageData = {
+        messages: [
+          {
+            message_content: 'test message',
+            llm_response: 'mock llm response'
+          },
+        ]
+      };
     
-    await expect(EntryServices.createEntryConversation(
-      mockEntry.id,
-      mockConfig.id,
-      mockMessageData
-    )).rejects.toThrow('Entry analysis not found.');
-  });
+      await expect(EntryServices.createEntryConversation(
+        mockEntry.id,
+        mockConfig.id,
+        mockMessageData
+      )).rejects.toThrow('Entry analysis not found.');
+    });
 
-  it('throws error when new EntryConversation has empty messages', async () => {
-    const mockEntry = new Entry({ journal: mockJournal.id, content: 'mock content' });
-    const mockEntryAnalysis = await EntryAnalysis.create({ entry: mockEntry.id });
-    mockEntry.analysis = mockEntryAnalysis.id;
-    await mockEntry.save();
-    const mockConfig = new Config({ model: {} });
-    const mockMessageData = {
-      messages: [
-      ]
-    };
+    it('throws error when new EntryConversation has empty messages', async () => {
+      const mockEntry = new Entry({ journal: mockJournal.id, content: 'mock content' });
+      const mockEntryAnalysis = await EntryAnalysis.create({ entry: mockEntry.id });
+      mockEntry.analysis = mockEntryAnalysis.id;
+      await mockEntry.save();
+      const mockConfig = new Config({ model: {} });
+      const mockMessageData = {
+        messages: [
+        ]
+      };
     
-    await expect(EntryServices.createEntryConversation(
-      mockEntry.id,
-      mockConfig.id,
-      mockMessageData
-    )).rejects.toThrow('No message to get completion for.');
-  });
+      await expect(EntryServices.createEntryConversation(
+        mockEntry.id,
+        mockConfig.id,
+        mockMessageData
+      )).rejects.toThrow('No message to get completion for.');
+    });
 
-  it('does not update EntryConversation if llm response is empty', async () => {
-    const mockEntry = new Entry({ journal: mockJournal.id, content: 'mock content' });
-    const mockEntryAnalysis = await EntryAnalysis.create({ entry: mockEntry.id });
-    mockEntry.analysis = mockEntryAnalysis.id;
-    await mockEntry.save();
-    const mockConfig = await Config.create({ model: {} });
-    const mockMessageData = {
-      messages: [
-        {
-          message_content: 'test message',
-          llm_response: 'mock llm response'
-        },
-      ]
-    };
-    const mockLlmContent = '';
-    jest.spyOn(CdGptServices, 'getChatContent').mockResolvedValue(mockLlmContent);
+    it('does not update EntryConversation if llm response is empty', async () => {
+      const mockEntry = new Entry({ journal: mockJournal.id, content: 'mock content' });
+      const mockEntryAnalysis = await EntryAnalysis.create({ entry: mockEntry.id });
+      mockEntry.analysis = mockEntryAnalysis.id;
+      await mockEntry.save();
+      const mockConfig = await Config.create({ model: {} });
+      const mockMessageData = {
+        messages: [
+          {
+            message_content: 'test message',
+            llm_response: 'mock llm response'
+          },
+        ]
+      };
+      const mockLlmContent = '';
+      jest.spyOn(CdGptServices, 'getChatContent').mockResolvedValue(mockLlmContent);
     
-    const sut = await EntryServices.createEntryConversation(
-      mockEntry.id,
-      mockConfig.id,
-      mockMessageData
-    );
+      const sut = await EntryServices.createEntryConversation(
+        mockEntry.id,
+        mockConfig.id,
+        mockMessageData
+      );
 
-    expect(sut.entry.toString()).toBe(mockEntry.id);
-    expect(sut.messages?.length).toBe(1);
-    expect((sut.messages as ChatMessage[])[0].message_content).toBe(mockMessageData.messages[0].message_content);
-    expect((sut.messages as ChatMessage[])[0].llm_response).toBe(mockMessageData.messages[0].llm_response);
+      expect(sut.entry.toString()).toBe(mockEntry.id);
+      expect(sut.messages?.length).toBe(1);
+      expect((sut.messages as ChatMessage[])[0].message_content).toBe(mockMessageData.messages[0].message_content);
+      expect((sut.messages as ChatMessage[])[0].llm_response).toBe(mockMessageData.messages[0].llm_response);
+    });
   });
-
 
   describe('updateEntry tests', () => {
     it('updates Entry with valid journal id, config id, and content', async () => {
@@ -412,6 +415,35 @@ describe('Entry service tests', () => {
       expect(sut.tags).toStrictEqual([]);
       expect(sut.analysis?.toString()).toBe(testAnalysis?.id);
       expect(testAnalysis?.analysis_content).toBe('Analysis not available');
+    });
+  });
+
+  describe('Update EntryAnalysis tests', () => {
+    it('updates EntryAnalysis', async () => {
+      const mockEntry = new Entry({ journal: mockJournal.id, content: 'mock content' });
+      const mockEntryAnalysis = await EntryAnalysis.create({ entry: mockEntry.id });
+      mockEntry.analysis = mockEntryAnalysis.id;
+      await mockEntry.save();
+      const updateContent = {
+        analysis_content: 'llm updated content',
+        title: 'llm updated title',
+        mood: 'llm updated mood',
+        tags: ['new tag'],
+      };
+      const mockConfig = await Config.create({ model: {} });
+      mockedCdGptServices.getAnalysisContent.mockResolvedValue(updateContent);
+  
+      const { errMessage, entry: sut } = await EntryServices.updateEntryAnalysis(mockEntry.id, mockConfig.id);
+      const testAnalysis = await EntryAnalysis.findById(sut.analysis);
+  
+      expect(errMessage).toBeUndefined();
+      expect(sut.title).toBe(updateContent.title);
+      expect(sut.journal.toString()).toBe(mockJournal.id);
+      expect(sut.content).toBe('mock content');
+      expect(sut.tags).toStrictEqual(updateContent.tags);
+      expect(sut.analysis?.toString()).toBe(testAnalysis?.id);
+      expect(sut.mood).toBe(updateContent.mood);
+      expect(testAnalysis?.analysis_content).toBe(updateContent.analysis_content);
     });
   });
 });


### PR DESCRIPTION
This PR refactors delete operations in controllers/entry into separate functions and moves them to a new file /models/services/entry/entry.ts. It also adds unit tests for the delete service functions.

In order to test deletes with the memory mongodb, I needed to deploy it as a replica set instead of as a standalone instance. This required changes to jest.setup.cjs. Although all unit tests pass, occasionally on teardown, the following error will appear:
```
Ran all test suites.
Teardown: Dropping test database...
Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:218:20) {
  errno: -4077,
  code: 'ECONNRESET',
  syscall: 'read'
}
```
This doesn't seem to affect anything, but I haven't been able to figure out why exactly it's happening. My best guess is that jest closes before every node in the replica set disconnects. This doesn't break anything, and it doesn't even affect the unit tests because it happens after they all finish running, but it's odd.