### PR TITLE
refactor!: create service layers for create, update, and delete operations

### DIFF
--- a/backend/src/controllers/entry/entry.ts
+++ b/backend/src/controllers/entry/entry.ts
@@ -100,26 +100,23 @@ export const updateEntry = async (
 
   try {
     const configId = await verifyJournalExists(journalId);
+    const { errMessage, entry: updatedEntry } = await EntryServices
+      .updateEntry(
+        entryId,
+        configId,
+        entryData,
+      );
 
-    try {
-      const { errMessage, entry: updatedEntry } = await EntryServices
-        .updateEntry(
-          entryId,
-          configId,
-          entryData,
-        );
-  
-      if (errMessage) {
-        req.flash('info', errMessage);
-      }
-      req.flash('success', 'Successfully updated entry.');
-      res.status(200).json({ ...updatedEntry.toObject(), flash: req.flash() });
-    } catch (updateError) {
-      // Handle error if no documents match entryId
-      throw new ExpressError((updateError as Error).message, 404);
+    if (errMessage) {
+      req.flash('info', errMessage);
     }
+    req.flash('success', 'Successfully updated entry.');
+    res.status(200).json({ ...updatedEntry.toObject(), flash: req.flash() });
   } catch (err) {
-    return next(err);
+    if (err instanceof ExpressError) {
+      return next(err);
+    }
+    return next(new ExpressError((err as Error).message, 404));
   }
 };
 
@@ -177,26 +174,25 @@ export const updateEntryAnalysis = async (
   try {
     const configId = await verifyJournalExists(journalId);
 
-    try {
-      const { errMessage, entry, entryAnalysis } = await EntryServices.updateEntryAnalysis(entryId, configId);
+    const { errMessage, entry, entryAnalysis } = await EntryServices.updateEntryAnalysis(entryId, configId);
     
-      if (errMessage) {
-        req.flash('info', errMessage);
-      }
-      req.flash('success', 'Successfully generated a new analysis.');
-      res
-        .status(200)
-        .json({
-          ...entryAnalysis.toObject(),
-          entry: entry.toObject(),
-          flash: req.flash(),
-        });
-    } catch (updateError) {
-      // Handle error if no documents match entryId
-      throw new ExpressError((updateError as Error).message, 404);
+    if (errMessage) {
+      req.flash('info', errMessage);
     }
+    req.flash('success', 'Successfully generated a new analysis.');
+    res
+      .status(200)
+      .json({
+        ...entryAnalysis.toObject(),
+        entry: entry.toObject(),
+        flash: req.flash(),
+      });
   } catch (error) {
-    return next(error);
+    if (error instanceof ExpressError) {
+      return next(error);
+    }
+    // Handle error if no documents match entryId
+    return next(new ExpressError((error as Error).message, 404));
   }
 };
 

--- a/backend/src/controllers/entry/entry.ts
+++ b/backend/src/controllers/entry/entry.ts
@@ -6,9 +6,8 @@ import { Journal } from '../../models/index.js';
 
 /**
  * Request body for create and update Entry operations,
- * i.e. all requests that go through validateEntry
  */
-export interface UpdateEntryRequestBody {
+export interface EntryRequestBody {
   title?: string;
   content?: string;
   mood?: string;
@@ -19,13 +18,13 @@ export interface UpdateEntryRequestBody {
   };
 }
 
-export interface UpdateChatRequestBody {
+/**
+ * Request body type for POST and PUT EntryConversation operations
+ */
+export interface EntryConversationRequestBody {
   messages: ChatMessage[];
 }
 
-/**
- * Get all entries in a specific journal.
- */
 export const getAllEntries = async (
   req: Request,
   res: Response
@@ -42,8 +41,6 @@ export const getAllEntries = async (
 
 /**
  * Create a new entry and analysis in a specific journal.
- * Request params journalId: string
- * Request body matches joiEntrySchema, but might be missing fields
  */
 export const createEntry = async (
   req: Request,
@@ -51,7 +48,7 @@ export const createEntry = async (
   next: NextFunction
 ) => {
   const { journalId } = req.params;
-  const entryData: UpdateEntryRequestBody = req.body;
+  const entryData: EntryRequestBody = req.body;
 
   try {
     const configId = await verifyJournalExists(journalId);
@@ -99,7 +96,7 @@ export const updateEntry = async (
   next: NextFunction
 ) => {
   const { entryId, journalId } = req.params;
-  const entryData: UpdateEntryRequestBody = req.body;
+  const entryData: EntryRequestBody = req.body;
 
   try {
     const configId = await verifyJournalExists(journalId);
@@ -118,8 +115,7 @@ export const updateEntry = async (
       req.flash('success', 'Successfully updated entry.');
       res.status(200).json({ ...updatedEntry.toObject(), flash: req.flash() });
     } catch (updateError) {
-      // Possible error from failing to find matching documents for entryId
-      // Setting appropriate error code here
+      // Handle error if no documents match entryId
       throw new ExpressError((updateError as Error).message, 404);
     }
   } catch (err) {
@@ -196,8 +192,7 @@ export const updateEntryAnalysis = async (
           flash: req.flash(),
         });
     } catch (updateError) {
-      // Possible error from failing to find matching documents for entryId
-      // Setting appropriate error code here
+      // Handle error if no documents match entryId
       throw new ExpressError((updateError as Error).message, 404);
     }
   } catch (error) {
@@ -228,9 +223,8 @@ export const createEntryConversation = async (
   next: NextFunction
 ) => {
   const { entryId, journalId } = req.params;
-  const messageData: UpdateChatRequestBody = req.body;
+  const messageData: EntryConversationRequestBody = req.body;
 
-  // Create new EntryConversation
   try {
     const configId = await verifyJournalExists(journalId);
 
@@ -240,7 +234,6 @@ export const createEntryConversation = async (
       messageData
     );
 
-    // Craft response body
     const entryConversation = response ? response.toObject() : {};
     req.flash('success', 'Successfully created conversation.');
     res.status(201).json({ ...entryConversation, flash: req.flash() });
@@ -258,7 +251,7 @@ export const updateEntryConversation = async (
   next: NextFunction
 ) => {
   const { chatId, journalId } = req.params;
-  const messageData: UpdateChatRequestBody = req.body;
+  const messageData: EntryConversationRequestBody = req.body;
 
   try {
     const configId = await verifyJournalExists(journalId);
@@ -271,7 +264,7 @@ export const updateEntryConversation = async (
 };
 
 /**
- * Checks if journal with jounalId exists and returns configId in journal.
+ * Checks if journal with journalId exists and returns configId in journal.
  * 
  * @param journalId id of journal to check
  * @returns configId

--- a/backend/src/controllers/entry/entry.ts
+++ b/backend/src/controllers/entry/entry.ts
@@ -5,7 +5,7 @@ import ExpressError from '../../utils/ExpressError.js';
 import { Journal } from '../../models/index.js';
 
 /**
- * Request body for create and update Entry operations,
+ * Request body type for POST and PUT Entry operations
  */
 export interface EntryRequestBody {
   title?: string;

--- a/backend/src/controllers/entry/entry.ts
+++ b/backend/src/controllers/entry/entry.ts
@@ -1,20 +1,35 @@
 import * as EntryServices from '../../models/services/entry/entry.js';
-import {
-  Entry,
-  EntryAnalysis,
-  EntryConversation,
-  Journal,
-} from '../../models/index.js';
 import { NextFunction, Request, Response } from 'express';
-import mongoose, { Document } from 'mongoose';
-import { EntryAnalysisType } from '../../models/entry/entryAnalysis.js';
+import { ChatMessage } from '../../models/entry/entryConversation.js';
 import ExpressError from '../../utils/ExpressError.js';
-import { validateEntryAnalysis } from '../../middleware/validation.js';
+import { Journal } from '../../models/index.js';
+
+/**
+ * Request body for create and update Entry operations,
+ * i.e. all requests that go through validateEntry
+ */
+export interface UpdateEntryRequestBody {
+  title?: string;
+  content?: string;
+  mood?: string;
+  tags?: string[];
+  privacy_settings?: {
+    public: boolean;
+    shared_with: string[];
+  };
+}
+
+export interface UpdateChatRequestBody {
+  messages: ChatMessage[];
+}
 
 /**
  * Get all entries in a specific journal.
  */
-export const getAllEntries = async (req: Request, res: Response) => {
+export const getAllEntries = async (
+  req: Request,
+  res: Response
+) => {
   const { journalId } = req.params;
 
   const entries = await EntryServices.getAllEntriesInJournal(journalId);
@@ -30,66 +45,40 @@ export const getAllEntries = async (req: Request, res: Response) => {
  * Request params journalId: string
  * Request body matches joiEntrySchema, but might be missing fields
  */
-export const createEntry = async (req: Request, res: Response, next: NextFunction) => {
+export const createEntry = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   const { journalId } = req.params;
+  const entryData: UpdateEntryRequestBody = req.body;
 
-  // Ensure that the journal exists
-  const journal = await Journal.findById(journalId);
-  if (!journal) {
-    return next(new ExpressError('Journal not found.', 404));
+  try {
+    const configId = await verifyJournalExists(journalId);
+
+    const { errMessage, entry: newEntry } = await EntryServices.createEntry(
+      journalId,
+      configId,
+      entryData
+    );
+  
+    if (errMessage) {
+      req.flash('info', errMessage);
+    }
+    res.status(201).json({ ...newEntry.toObject(), flash: req.flash() });
+  } catch (err) {
+    return next(err);
   }
-
-  validateEntryAnalysis(req, res, async (err: ExpressError) => {
-    if (err) {
-      return next(err); // Handle any validation errors
-    }
-
-    // If validation is successful, proceed to create the entry and analysis
-    const entryData = req.body;
-
-    const newEntry = new Entry({ journal: journalId, ...entryData });
-    const newAnalysis = new EntryAnalysis({
-      entry: newEntry.id,
-      analysis_content: entryData.analysis_content,
-    });
-
-    // Associate the entry with the analysis
-    newEntry.analysis = newAnalysis._id;
-    if (!journal.config) {
-      return next(new ExpressError('Journal config not found.', 404));
-    }
-    // Get the analysis content for the entry
-    try {
-      const analysis = await newAnalysis.getAnalysisContent(
-        journal.config.toString(),
-        newEntry.content
-      );
-
-      // Complete the entry and analysis with the analysis content if available
-      if (analysis) {
-        newEntry.title = analysis.title;
-        newEntry.mood = analysis.mood;
-        newEntry.tags = analysis.tags;
-
-        newAnalysis.analysis_content = analysis.analysis_content;
-      }
-    } catch (analysisError) {
-      req.flash('info', (analysisError as Error).message);
-    } finally {
-      await newEntry.save();
-      await newAnalysis.save();
-    }
-
-    res
-      .status(201)
-      .json({ ...(await newEntry.save()).toObject(), flash: req.flash() });
-  });
 };
 
 /**
  * Get an entry and all associated documents by ID.
  */
-export const getAnEntry = async (req: Request, res: Response, next: NextFunction) => {
+export const getAnEntry = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   const { entryId } = req.params;
 
   try {
@@ -104,112 +93,70 @@ export const getAnEntry = async (req: Request, res: Response, next: NextFunction
 /**
  * Update an entry by ID.
  */
-export const updateEntry = async (req: Request, res: Response, next: NextFunction) => {
+export const updateEntry = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   const { entryId, journalId } = req.params;
+  const entryData: UpdateEntryRequestBody = req.body;
 
-  const journal = await Journal.findById(journalId);
-  if (!journal) {
-    return next(new ExpressError('Journal not found.', 404));
-  }
+  try {
+    const configId = await verifyJournalExists(journalId);
 
-  validateEntryAnalysis(req, res, async (err: ExpressError) => {
-    if (err) {
-      return next(err);
-    }
-
-    const entryData = req.body;
-    const updatedEntry = await Entry.findById(entryId);
-    if (!updatedEntry) {
-      return next(new ExpressError('Entry not found.', 404));
-    }
-
-    if (entryData.content) {
-      // Update the entry with the new data
-      updatedEntry.content = entryData.content;
-
-      // Update the analysis content for the entry with a new analysis
-      const oldAnalysis = await EntryAnalysis.findOne({ entry: entryId });
-      if (!oldAnalysis) {
-        return next(new ExpressError('Entry analysis not found.', 404));
-      }
-      if (!journal.config) {
-        return next(new ExpressError('Journal config not found.', 404));
-      }
-      try {
-        const analysis = await oldAnalysis.getAnalysisContent(
-          journal.config.toString(),
-          updatedEntry.content
+    try {
+      const { errMessage, entry: updatedEntry } = await EntryServices
+        .updateEntry(
+          entryId,
+          configId,
+          entryData,
         );
-
-        if (analysis) {
-          updatedEntry.title = analysis.title;
-          updatedEntry.mood = analysis.mood;
-          updatedEntry.tags = analysis.tags;
-
-          oldAnalysis.analysis_content = analysis.analysis_content;
-        }
-      } catch (analysisError) {
-        req.flash('info', (analysisError as Error).message);
-      } finally {
-        await updatedEntry.save();
-        await oldAnalysis.save();
+  
+      if (errMessage) {
+        req.flash('info', errMessage);
       }
-    } else if (entryData.title) {
-      updatedEntry.title = entryData.title;
-      await updatedEntry.save();
+      req.flash('success', 'Successfully updated entry.');
+      res.status(200).json({ ...updatedEntry.toObject(), flash: req.flash() });
+    } catch (updateError) {
+      // Possible error from failing to find matching documents for entryId
+      // Setting appropriate error code here
+      throw new ExpressError((updateError as Error).message, 404);
     }
-
-    req.flash('success', 'Successfully updated entry.');
-    res.status(200).json({ ...updatedEntry.toObject(), flash: req.flash() });
-  });
+  } catch (err) {
+    return next(err);
+  }
 };
 
 /**
  * Delete an entry by ID and all associated documents.
  */
-export const deleteEntry = async (req: Request, res: Response, next: NextFunction) => {
+export const deleteEntry = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   const { entryId } = req.params;
-
-  // Start a session and transaction for atomicity
-  const session = await mongoose.startSession();
-  session.startTransaction();
-
   try {
-    // Delete the entry
-    const response = await Entry.findByIdAndDelete(entryId, { session });
-
-    if (!response) {
-      return next(new ExpressError('Entry not found.', 404));
+    await EntryServices.deleteEntry(entryId);
+    req.flash('success', 'Successfully deleted entry.');
+    res.status(200).json({ flash: req.flash() });
+  } catch (err) {
+    const errMessage = (err as Error).message;
+    if (errMessage === 'Entry not found.') {
+      return next(new ExpressError((err as Error).message, 404));  
     }
-
-    // Delete associated documents
-    await EntryConversation.deleteMany({ entry: entryId }, { session });
-    await EntryAnalysis.deleteMany({ entry: entryId }, { session });
-
-    // Commit the transaction
-    await session.commitTransaction();
-  } catch {
-    // If an error occurs, abort the transaction
-    await session.abortTransaction();
-    return next(
-      new ExpressError(
-        'An error occurred while attempting to delete the entry.',
-        500
-      )
-    );
-  } finally {
-    // End the session
-    session.endSession();
+    return next(new ExpressError('An error occurred while attempting to delete the entry.', 500));
   }
-
-  req.flash('success', 'Successfully deleted entry.');
-  res.status(200).json({ flash: req.flash() });
 };
 
 /**
  * Get an entry and its analysis by ID.
  */
-export const getEntryAnalysis = async (req: Request, res: Response, next: NextFunction) => {
+export const getEntryAnalysis = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   const { entryId } = req.params;
 
   const entryAnalysis = await EntryServices.getPopulatedEntryAnalysis(entryId);
@@ -224,53 +171,38 @@ export const getEntryAnalysis = async (req: Request, res: Response, next: NextFu
 /**
  * Update the analysis of an entry by entry ID.
  */
-export const updateEntryAnalysis = async (req: Request, res: Response, next: NextFunction) => {
+export const updateEntryAnalysis = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   const { entryId, journalId } = req.params;
 
-  // Ensure that the journal exists
-  const journal = await Journal.findById(journalId);
-  if (!journal) {
-    return next(new ExpressError('Journal not found.', 404));
-  }
-
-  const entry = await Entry.findById(entryId);
-
-  if (!entry) {
-    return next(new ExpressError('Entry not found.', 404));
-  }
-
-  const entryAnalysis = await EntryAnalysis.findOne({ entry: entryId });
-  if (!entryAnalysis) {
-    return next(new ExpressError('Entry not found.', 404));
-  }
-  if (!journal.config) {
-    return next(new ExpressError('Journal config not found.', 404));
-  }
   try {
-    const analysis = await entryAnalysis.getAnalysisContent(
-      journal.config.toString(),
-      entry.content
-    );
+    const configId = await verifyJournalExists(journalId);
 
-    // Complete the entry and analysis with the analysis content if available
-    if (analysis) {
-      entry.title = analysis.title;
-      entry.mood = analysis.mood;
-      entry.tags = analysis.tags;
-
-      entryAnalysis.analysis_content = analysis.analysis_content;
-
-      entryAnalysis.save();
-      entry.save();
+    try {
+      const { errMessage, entry, entryAnalysis } = await EntryServices.updateEntryAnalysis(entryId, configId);
+    
+      if (errMessage) {
+        req.flash('info', errMessage);
+      }
       req.flash('success', 'Successfully generated a new analysis.');
+      res
+        .status(200)
+        .json({
+          ...entryAnalysis.toObject(),
+          entry: entry.toObject(),
+          flash: req.flash(),
+        });
+    } catch (updateError) {
+      // Possible error from failing to find matching documents for entryId
+      // Setting appropriate error code here
+      throw new ExpressError((updateError as Error).message, 404);
     }
-  } catch (err) {
-    req.flash('info', (err as Error).message);
+  } catch (error) {
+    return next(error);
   }
-
-  res
-    .status(200)
-    .json({ ...entryAnalysis.toObject(), entry: entry.toObject(), flash: req.flash() });
 };
 
 /**
@@ -290,126 +222,67 @@ export const getEntryConversation = async (req: Request, res: Response) => {
 /**
  * Create a conversation for a specific entry.
  */
-export const createEntryConversation = async (req: Request, res: Response, next: NextFunction) => {
+export const createEntryConversation = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   const { entryId, journalId } = req.params;
-  const messageData = req.body;
+  const messageData: UpdateChatRequestBody = req.body;
 
-  const newConversation = new EntryConversation({
-    entry: entryId,
-    ...messageData,
-  });
-
-  // Get the config from the journal
-  const journal = await Journal.findById(journalId);
-  if (!journal) {
-    return next(new ExpressError('Journal not found.', 404));
-  }
-  if (!journal.config) {
-    return next(new ExpressError('Journal config not found.', 404));
-  }
-
-  // Get an entry with the analysis
-  const entry = await Entry.findById(entryId).populate<{ analysis: Document<EntryAnalysisType> }>('analysis');
-  if (!entry) {
-    return next(new ExpressError('Entry not found.', 404));
-  }
-  if (!entry.analysis) {
-    return next(new ExpressError('Entry analysis not found.', 404));
-  }
-
-  // Associate the conversation with the entry
-  entry.conversation = newConversation._id;
-  await entry.save();
-
+  // Create new EntryConversation
   try {
-    if (entry.analysis === undefined) {
-      return next(new ExpressError('Entry analysis not found.' , 500));
-    }
-    const llmResponse = await newConversation.getChatContent(
-      journal.config.toString(),
-      entry.analysis.id,
-      messageData.messages[0].message_content
+    const configId = await verifyJournalExists(journalId);
+
+    const response = await EntryServices.createEntryConversation(
+      entryId,
+      configId,
+      messageData
     );
 
-    // If the chat is not empty, update the llm_response
-    if (!newConversation.messages) {
-      return next(new ExpressError('No message to get completion for.', 404));
-    }
-    if (llmResponse) {
-      newConversation.messages[0].llm_response = llmResponse;
-    }
-  } catch (err) {
-    return next(err);
+    // Craft response body
+    const entryConversation = response ? response.toObject() : {};
+    req.flash('success', 'Successfully created conversation.');
+    res.status(201).json({ ...entryConversation, flash: req.flash() });
+  } catch (error) {
+    return next(error);
   }
-
-  await newConversation.save();
-
-  const response = await EntryConversation.findOne({ entry: entryId });
-  const entryConversation = response ? response.toObject() : {};
-
-  req.flash('success', 'Successfully created conversation.');
-  res.status(201).json({ ...entryConversation, flash: req.flash() });
 };
 
 /**
  * Update a conversation for a specific entry.
  */
-export const updateEntryConversation = async (req: Request, res: Response, next: NextFunction) => {
+export const updateEntryConversation = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   const { chatId, journalId } = req.params;
-  const messageData = req.body;
+  const messageData: UpdateChatRequestBody = req.body;
 
-  // Get the config from the journal
+  try {
+    const configId = await verifyJournalExists(journalId);
+
+    const response = await EntryServices.updateEntryConversation(chatId, configId, messageData);
+    res.status(200).json({ ...response.toObject(), flash: req.flash() });
+  } catch (error) {
+    return next(error);
+  }
+};
+
+/**
+ * Checks if journal with jounalId exists and returns configId in journal.
+ * 
+ * @param journalId id of journal to check
+ * @returns configId
+ */
+async function verifyJournalExists(journalId: string): Promise<string> {
   const journal = await Journal.findById(journalId);
   if (!journal) {
-    return next(new ExpressError('Journal not found.', 404));
+    throw new ExpressError('Journal not found.', 404);
   }
-
-  // Get the conversation from the database
-  const conversation = await EntryConversation.findById(chatId);
-  if (!conversation) {
-    return next(new ExpressError('Entry conversation not found.', 404));
-  }
-  if (!conversation.messages) {
-    return next(new ExpressError('Entry conversation messages not found.', 404));
-  }
-
-  // Get the analysis associated with the entry
-  const analysis = await EntryAnalysis.findOne({ entry: conversation.entry });
-  if (!analysis) {
-    return next(new ExpressError('Entry analysis not found.', 404));
-  }
-
   if (!journal.config) {
-    return next(new ExpressError('Journal config not found.', 404));
+    throw new ExpressError('Journal config not found.', 404);
   }
-  try {
-    const llmResponse = await conversation.getChatContent(
-      journal.config.toString(),
-      analysis.id,
-      messageData.messages[0].message_content,
-      conversation.messages
-    );
-
-    // If the chat is not empty, update the llm_response
-    if (llmResponse) {
-      messageData.messages[0].llm_response = llmResponse;
-    }
-  } catch (err) {
-    return next(err);
-  }
-
-  const response = await EntryConversation.findOneAndUpdate(
-    { _id: chatId },
-    {
-      $push: {
-        ...messageData,
-      },
-    },
-    { new: true }
-  );
-  if (!response) {
-    return next(new ExpressError('Failed to update entry conversation.', 500));
-  }
-
-  res.status(200).json({ ...response.toObject(), flash: req.flash() });
-};
+  return journal.config.toString();
+}

--- a/backend/src/models/services/entry/entry.ts
+++ b/backend/src/models/services/entry/entry.ts
@@ -203,8 +203,7 @@ export async function createEntryConversation(
   configId: string,
   messageData: EntryConversationRequestBody
 ) {
-  // Joi validation should catch this before it gets here
-  // TODO: #198 test this case to check if conditional is necessary
+  // TODO: #198 check if this conditional is necessary; Joi validation should catch this before this line
   if (!messageData.messages || messageData.messages.length === 0) {
     throw new ExpressError('No message to get completion for.', 404);
   }
@@ -329,7 +328,7 @@ async function _populateChatContent(
   configId: string,
   analysis: HydratedDocument<EntryAnalysisType>,
   messageData: EntryConversationRequestBody,
-  // TODO: #174
+  // TODO: #174 define conversation type
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   conversation: any
 ): Promise<HydratedDocument<EntryConversationType>> {

--- a/backend/src/models/services/entry/entry.ts
+++ b/backend/src/models/services/entry/entry.ts
@@ -3,7 +3,7 @@ import {
   EntryAnalysis,
   EntryConversation,
 } from '../../index.js';
-import { UpdateChatRequestBody, UpdateEntryRequestBody } from '../../../controllers/entry/entry.js';
+import { EntryConversationRequestBody, EntryRequestBody } from '../../../controllers/entry/entry.js';
 import mongoose, { HydratedDocument } from 'mongoose';
 import { EntryAnalysisType } from '../../entry/entryAnalysis.js';
 import { EntryConversationType } from '../../entry/entryConversation.js';
@@ -139,7 +139,7 @@ export async function getEntryConversation(entryId: string) {
 export async function createEntry(
   journalId: string,
   configId: string,
-  entryData: UpdateEntryRequestBody,
+  entryData: EntryRequestBody,
 ) {
   // Create new Entry and corresponding EntryAnalysis
   const newEntry = new Entry({ journal: journalId, ...entryData });
@@ -165,7 +165,7 @@ export async function createEntry(
 export async function updateEntry(
   entryId: string,
   configId: string,
-  entryData: UpdateEntryRequestBody,
+  entryData: EntryRequestBody,
 ) {
   const { title: entryTitle, content: entryContent } = entryData;
   const { entry, entryAnalysis } = await _verifyEntry(entryId);
@@ -251,7 +251,7 @@ export async function deleteEntry(
 export async function createEntryConversation(
   entryId: string,
   configId: string,
-  messageData: UpdateChatRequestBody
+  messageData: EntryConversationRequestBody
 ) {
   /**
    * I don't think this case will ever get used because joi validation
@@ -301,7 +301,7 @@ export async function createEntryConversation(
 export async function updateEntryConversation(
   chatId: string,
   configId: string,
-  messageData: UpdateChatRequestBody
+  messageData: EntryConversationRequestBody
 ) {
   const { conversation, analysis } = await _verifyEntryConversation(chatId);
 
@@ -382,7 +382,7 @@ async function _updateEntry(
 async function _populateChatContent(
   configId: string,
   analysis: HydratedDocument<EntryAnalysisType>,
-  messageData: UpdateChatRequestBody,
+  messageData: EntryConversationRequestBody,
   // Can't use HydratedDocument<EntryConversationType> because it doesn't have model methods
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   conversation: any

--- a/backend/src/models/services/entry/entry.ts
+++ b/backend/src/models/services/entry/entry.ts
@@ -1,15 +1,22 @@
 import {
-  Config,
   Entry,
   EntryAnalysis,
   EntryConversation,
 } from '../../index.js';
-import CdGpt from '../../../assistants/gpts/CdGpt.js';
+import { UpdateChatRequestBody, UpdateEntryRequestBody } from '../../../controllers/entry/entry.js';
+import mongoose, { HydratedDocument } from 'mongoose';
 import { EntryAnalysisType } from '../../entry/entryAnalysis.js';
 import { EntryConversationType } from '../../entry/entryConversation.js';
 import { EntryType } from '../../entry/entry.js';
-import { HydratedDocument } from 'mongoose';
+import ExpressError from '../../../utils/ExpressError.js';
 
+/**
+ * Return value of operations that create or update Entry
+ */
+interface EntryUpdateResponse {
+  errMessage?: string;
+  entry: HydratedDocument<EntryType>;
+}
 
 /**
  * Returns array of all entries in a journal.
@@ -30,6 +37,38 @@ export async function getAllEntriesInJournal(
 }
 
 /**
+ * Gets Entry with entryId.
+ * 
+ * @param entryId id of Entry
+ * @returns Entry or null
+ */
+export async function getEntryById(entryId: string) {
+  try {
+    const entry = await Entry.findById(entryId);
+    return entry;
+  } catch (error) {
+    console.error(error);
+  }
+  return null;
+}
+
+/**
+ * Gets EntryAnalysis for Entry with entryId.
+ * 
+ * @param entryId id of Entry associated with analysis
+ * @returns EntryAnalysis or null
+ */
+export async function getEntryAnalysisById(entryId: string) {
+  try {
+    const analysis = await EntryAnalysis.findOne({ entry: entryId });
+    return analysis;
+  } catch (error) {
+    console.error(error);
+  }
+  return null;
+}
+
+/**
  * Gets Entry with all referenced properties populated.
  *
  * @param entryId string of Entry._id to get
@@ -37,12 +76,17 @@ export async function getAllEntriesInJournal(
  * @returns Populated entry document matching entryId
  */
 export async function getPopulatedEntry(entryId: string) {
-  return await Entry
-    .findById(entryId)
-    .populate<{
-      analysis: EntryAnalysisType,
-      conversation: EntryConversationType
-    }>('analysis conversation');
+  try {
+    return await Entry
+      .findById(entryId)
+      .populate<{
+        analysis: EntryAnalysisType,
+        conversation: EntryConversationType
+      }>('analysis conversation');
+  } catch (error) {
+    console.error(error);
+  }
+  return null;
 }
 
 /**
@@ -79,135 +123,307 @@ export async function getEntryConversation(entryId: string) {
   return null;
 }
 
-// TODO: All functions below are in-progress for create operations and are not being used currently. DL will be working on them in other PRs
-
 /**
- * Creates a new entry in journalId with entryContent as content
- * @param journalId Journal._id as string
- * @param entryContent body of entry
- * @returns new Entry document on success, and null on error.
+ * Creates a new Entry and corresponding EntryAnalysis in Journal
+ * with journalId with entryContent as content
+ *
+ * This function doesn't throw errors because the original controller
+ * handled them by creating a flash message with the error and continuing to
+ * respond normally.
+ * 
+ * @param journalId id of journal where creating new entry
+ * @param configId id of config to use
+ * @param entryData body of entry
+ * @returns new Entry document with reference to EntryAnalysis
  */
 export async function createEntry(
   journalId: string,
-  entryContent: object
-): Promise<HydratedDocument<EntryType> | null> {
-  /**
-   * TODO: may want to define entryContent type.
-   * Currently, it's based on EntryValidation and Entry joi schemas together b/c validation middleware.
-   * Takes on validation value but b/c mongoose strict mode, non-schema fields are dropped
-   */
-  try {
-    const newEntry = await Entry.create({ journal: journalId, ...entryContent });
-    return newEntry;
-  } catch (err) {
-    console.error(err);
-  }
-  return null;
-}
-
-/**
- * Creates empty EntryAnalysis for an Entry, and updates entry with
- * refernces to new EntryAnalysis.
- * @param configId Config._id as string
- * @param refEntry Document of target Entry to generate analysis for
- * @returns new EntryAnalysis for refEntry
- */
-export async function createEntryAnalysis(
   configId: string,
-  refEntry: HydratedDocument<EntryType>
-): Promise<HydratedDocument<EntryAnalysisType>> {
-  const newAnalysis = await EntryAnalysis.create({
-    entry: refEntry.id,
+  entryData: UpdateEntryRequestBody,
+) {
+  // Create new Entry and corresponding EntryAnalysis
+  const newEntry = new Entry({ journal: journalId, ...entryData });
+  const newAnalysis = new EntryAnalysis({
+    entry: newEntry.id,
   });
 
   // Associate the entry with the analysis
-  refEntry.analysis = newAnalysis.id;
-  await refEntry.save();
+  newEntry.analysis = newAnalysis.id;
 
-  return newAnalysis;
+  return await _updateEntry(newEntry, newAnalysis, configId);
 }
 
 /**
- * Generates analysis body for refEntry, and updates refEntry and refAnalysis
- * with analysis response.
- * @param configId Config._id as string
- * @param refEntry Document of target Entry to generate analysis for
- * @param refAnalysis Document of EntryAnalysis to generate analysis for
+ * Updates Entry with entryId and associated EntryAnalysis.
+ * If content changes, will generate new LLM analysis.
+ * 
+ * @param entryId id of Entry to update
+ * @param configId id of Config for LLM
+ * @param entryData body of entry
+ * @returns updated Entry and error message if error ocurred
  */
-export async function populateAnalysisContent(
+export async function updateEntry(
+  entryId: string,
   configId: string,
-  refEntry: HydratedDocument<EntryType>,
-  refAnalysis: HydratedDocument<EntryAnalysisType>
-): Promise<void> {
-  try {
-    const analysis = await getAnalysisContent(
-      configId,
-      refEntry.content
-    );
+  entryData: UpdateEntryRequestBody,
+) {
+  const { title: entryTitle, content: entryContent } = entryData;
+  const { entry, entryAnalysis } = await _verifyEntry(entryId);
 
+  if (entryContent) {
+    entry.content = entryContent;
+    return await _updateEntry(entry, entryAnalysis, configId);
+  } else if (entryTitle) {
+    entry.title = entryTitle;
+    await entry.save();
+  }
+  return { entry: entry };
+}
+
+/**
+ * Generates new LLM analysis for EntryAnalysis associated with entryId
+ * and updates fields.
+ * 
+ * @param entryId id of entry associated with EntryAnalysis to update
+ * @param configId id of config to use for LLM
+ * @returns updated EntryAnalysis, Entry, and possibly error message
+ */
+export async function updateEntryAnalysis(
+  entryId: string,
+  configId: string,
+) {
+  const { entry, entryAnalysis } = await _verifyEntry(entryId);
+  return {
+    ...await _updateEntry(entry, entryAnalysis, configId),
+    entryAnalysis: entryAnalysis 
+  };
+}
+
+/**
+ * Deletes Entry by ID and associated EntryConversation and EntryAnalysis.
+ * 
+ * @param entryId id of entry to delete
+ */
+export async function deleteEntry(
+  entryId: string
+): Promise<void> {
+  // Start a session and transaction for atomicity
+  const session = await mongoose.startSession();
+  session.startTransaction();
+
+  try {
+    // Delete the entry
+    const response = await Entry.findByIdAndDelete(entryId, { session });
+
+    if (!response) {
+      throw new Error('Entry not found.');
+    }
+
+    // Delete associated documents
+    await EntryConversation.deleteMany({ entry: entryId }, { session });
+    await EntryAnalysis.deleteMany({ entry: entryId }, { session });
+
+    // Commit the transaction
+    await session.commitTransaction();
+  } catch (error) {
+    // If an error occurs, abort the transaction
+    await session.abortTransaction();
+    throw error;
+  } finally {
+    // End the session
+    session.endSession();
+  }
+}
+
+/**
+ * Creates new EntryConversation for an Entry and populates with LLM response
+ * 
+ * This function throws errors to replicate how the original function
+ * handled them, which was to create a new error and call the error handler.
+ * The controller is responsible for catching errors and calling
+ * the error handler when using this function.
+ * 
+ * @param entryId id of Entry to create EntryConversation for
+ * @param messageData user-submitted messages to create conversation for
+ * @param configId id of Config for LLM
+ * @returns new EntryConversation from messageData
+ */
+export async function createEntryConversation(
+  entryId: string,
+  configId: string,
+  messageData: UpdateChatRequestBody
+) {
+  /**
+   * I don't think this case will ever get used because joi validation
+   * rejects empty messages, and that happens before hitting this function, but it's defensive
+   */
+  if (!messageData.messages || messageData.messages.length === 0) {
+    // TODO: try removing HTTP stuff from here
+    throw new ExpressError('No message to get completion for.', 404);
+  }
+  // Get an entry with the analysis
+  const { entry, entryAnalysis } = await _verifyEntry(entryId);
+  
+  const newConversation = new EntryConversation({
+    entry: entryId,
+    messages: messageData.messages,
+  });
+
+  // Associate the conversation with the entry
+  entry.conversation = newConversation.id;
+  
+  // TODO: try to use _populateChatContent. Can't currently because this doesn't append; it modifies in place
+  const llmResponse = await newConversation.getChatContent(
+    configId,
+    entryAnalysis.id,
+    messageData.messages[0].message_content
+  );
+  
+  if (llmResponse) {
+    // Messages defined because messageData.messages defined
+    newConversation.messages![0].llm_response = llmResponse;
+  }
+  await newConversation.save();
+  await entry.save();
+
+  return newConversation;
+}
+
+/**
+ * Updates EntryConversation associated with chatId with messages in messageData
+ * and generates LLM response to them.
+ * 
+ * @param chatId id of EntryConversation
+ * @param configId id of Config for LLM
+ * @param messageData messages to update EntryConversation with
+ * @returns Updated EntryConversation
+ */
+export async function updateEntryConversation(
+  chatId: string,
+  configId: string,
+  messageData: UpdateChatRequestBody
+) {
+  const { conversation, analysis } = await _verifyEntryConversation(chatId);
+
+  return await _populateChatContent(configId, analysis, messageData, conversation);
+}
+
+/**
+ * Private function for checking if Entry and EntryAnalysis associated with
+ * entryId exist.
+ * 
+ * @param entryId id associated with Entry and EntryAnalysis to check
+ * @returns Entry and EntryAnalysis associated with entryId
+ */
+async function _verifyEntry(entryId: string) {
+  const entry = await getEntryById(entryId);
+  if (!entry) {
+    throw new Error('Entry not found.');
+  }
+  const entryAnalysis = await getEntryAnalysisById(entryId);
+  if (!entryAnalysis) {
+    throw new Error('Entry analysis not found.');
+  }
+  return { entry, entryAnalysis };
+}
+
+/**
+ * Private function for updating Entry and EntryAnalysis with LLM content.
+ * 
+ * @param updatedEntry Entry to update
+ * @param oldAnalysis EntryAnalysis to update with LLM content
+ * @param configId id of Config for LLM
+ * @returns Entry and EntryAnalysis updated with LLM content, and error message on error
+ */
+async function _updateEntry(
+  updatedEntry: HydratedDocument<EntryType>,
+  // Can't use HydratedDocument<EntryAnalysisType> because it doesn't have model methods
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  oldAnalysis: any, 
+  configId: string
+) {
+  // Creating return object to push error handling into service rather than controller
+  const updateEntryResult: EntryUpdateResponse = {
+    entry: updatedEntry,
+  };
+  try {
+    const analysis = await oldAnalysis.getAnalysisContent(
+      configId,
+      updatedEntry.content
+    );
+  
     // Complete the entry and analysis with the analysis content if available
     if (analysis) {
-      refEntry.title = analysis.title;
-      refEntry.mood = analysis.mood;
-      refEntry.tags = analysis.tags;
-
-      refAnalysis.analysis_content = analysis.analysis_content;
+      updatedEntry.title = analysis.title;
+      updatedEntry.mood = analysis.mood;
+      updatedEntry.tags = analysis.tags;
+  
+      // TODO: you might validate here instead, not use middleware
+      oldAnalysis.analysis_content = analysis.analysis_content;
     }
-    await refEntry.save();
-    await refAnalysis.save();
-  } catch (err) {
-    console.error(err);
-    throw err;
+  } catch (analysisError) {
+    updateEntryResult.errMessage = (analysisError as Error).message;
+  } finally {
+    await updatedEntry.save();
+    await oldAnalysis.save();
   }
+  return updateEntryResult;
 }
 
 /**
- * Calls LLM API to retrieve analysis for entry content.
- * @param configId Config._id for LLM to use
- * @param content user entry to generate analysis of
- * @returns LLM analysis JSON
+ * Private function for updating EntryConversation with LLM content based on messageData.
+ * 
+ * @param configId id of Config for LLM
+ * @param analysis EntryAnalysis
+ * @param messageData messages to get LLM content for
+ * @param conversation EntryConversation to update
+ * @returns EntryConversation updated with LLM content
  */
-async function getAnalysisContent(configId: string, content: string): Promise<any> {
-  const config = await Config.findById(configId);
+async function _populateChatContent(
+  configId: string,
+  analysis: HydratedDocument<EntryAnalysisType>,
+  messageData: UpdateChatRequestBody,
+  // Can't use HydratedDocument<EntryConversationType> because it doesn't have model methods
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  conversation: any
+): Promise<HydratedDocument<EntryConversationType>> {
+  const llmResponse = await conversation.getChatContent(
+    configId,
+    analysis.id,
+    messageData.messages[0].message_content,
+    conversation.messages
+  );
 
-  if (!config) {
-    throw new Error('Configure your account settings to get an analysis.');
-  } else if (config.apiKey) {
-    try {
-      // Remove an API key from a legacy config
-      await Config.findByIdAndUpdate(config._id, { $unset: { apiKey: 1 } });
-    } catch (err) {
-      if (typeof err === 'string') {
-        throw new Error(err);
-      } else if (err instanceof Error) {
-        throw err;
-      }
-    }
+  // If the chat is not empty, update the llm_response
+  if (llmResponse) { // TODO: this will drop chats that fail to get llm response. Is that fine?
+    messageData.messages[0].llm_response = llmResponse;
+    conversation.messages?.push(messageData.messages[0]);
+    await conversation.save();
   }
+  return conversation;
+}
 
-  const cdGpt = new CdGpt(process.env.OPENAI_API_KEY, config.model.analysis);
-
-  cdGpt.seedAnalysisMessages();
-  cdGpt.addUserMessage({ analysis: content });
-
-  //TODO: replace type with better fitting one
-  const analysisCompletion: any = await cdGpt.getAnalysisCompletion();
-
-  if (analysisCompletion.error) {
-    throw new Error(analysisCompletion.error.message);
+/**
+ * Private function for checking if EntryConversation and EntryAnalysis
+ * associated with chatId exist.
+ * 
+ * @param chatId id of EntryConversation to verify
+ * @returns EntryConversation and EntryAnalysis associated with chatId
+ */
+async function _verifyEntryConversation(
+  chatId: string
+) {
+  // TODO: try removing HTTP stuff from here
+  const conversation = await EntryConversation.findById(chatId);
+  if (!conversation) {
+    throw new ExpressError('Entry conversation not found.', 404);
   }
-
-  const response = JSON.parse(analysisCompletion.choices[0].message.content);
-
-  const { reframed_thought: reframing, distortion_analysis: analysis, impact_assessment: impact, affirmation, is_healthy: isHealthy } = response;
-
-  if (!isHealthy) {
-    if (!analysis || !impact || !reframing) {
-      throw new Error('Analysis content is not available.');
-    }
-
-    response.analysis_content = analysis + ' ' + impact + ' Think, "' + reframing + '"' || affirmation;
-  } else response.analysis_content = affirmation;
-
-  return response;
+  if (!conversation.messages) {
+    throw new ExpressError('Entry conversation messages not found.', 404);
+  }
+  const analysis = await EntryAnalysis.findOne({ entry: conversation.entry });
+  if (!analysis) {
+    throw new ExpressError('Entry analysis not found.', 404);
+  }
+  return { conversation, analysis };
 }

--- a/backend/tests/jest.setup.cjs
+++ b/backend/tests/jest.setup.cjs
@@ -1,13 +1,13 @@
 require('dotenv').config();
-const MongoMemoryServer = require('mongodb-memory-server').MongoMemoryServer;
+const { MongoMemoryReplSet } = require('mongodb-memory-server');
 const mongoose = require('mongoose');
 
 module.exports = async () => {
   console.log('\nSetup: config mongodb for testing...');
   // https://typegoose.github.io/mongodb-memory-server/docs/guides/integration-examples/test-runners/
-  const instance = await MongoMemoryServer.create();
-  const uri = instance.getUri();
-  global.__MONGOINSTANCE = instance;
+  const replSet = await MongoMemoryReplSet.create({ replSet: { count: 3 } });
+  const uri = replSet.getUri();
+  global.__MONGOREPLSET = replSet;
   process.env.MONGO_URI = uri.slice(0, uri.lastIndexOf('/'));
 
   // Make sure the database is empty before running tests.

--- a/backend/tests/jest.teardown.cjs
+++ b/backend/tests/jest.teardown.cjs
@@ -3,6 +3,6 @@ require('dotenv').config();
 module.exports = async () => {
   console.log('Teardown: Dropping test database...');
   // https://typegoose.github.io/mongodb-memory-server/docs/guides/integration-examples/test-runners/
-  const instance = global.__MONGOINSTANCE;
-  await instance.stop();
+  const replSet = global.__MONGOREPLSET;
+  await replSet.stop();
 };

--- a/backend/tests/jest.teardown.cjs
+++ b/backend/tests/jest.teardown.cjs
@@ -3,6 +3,6 @@ require('dotenv').config();
 module.exports = async () => {
   console.log('Teardown: Dropping test database...');
   // https://typegoose.github.io/mongodb-memory-server/docs/guides/integration-examples/test-runners/
-  const replSet = global.__MONGOREPLSET;
-  await replSet.stop();
+  // Stop the MongoMemoryReplSet instance assigned to global variable in jest.setup.cjs
+  await global.__MONGOREPLSET.stop();
 };

--- a/backend/tests/models/services/entry/entry.test.ts
+++ b/backend/tests/models/services/entry/entry.test.ts
@@ -3,15 +3,13 @@
  */
 
 import * as EntryServices from '../../../../src/models/services/entry/entry.js';
-import { Entry, EntryAnalysis, EntryConversation, Journal, User } from '../../../../src/models/index.js';
+import { Config, Entry, EntryAnalysis, EntryConversation, Journal, User } from '../../../../src/models/index.js';
 import mongoose, { HydratedDocument } from 'mongoose';
-import { EntryType } from '../../../../src/models/entry/entry.js';
 import { JournalType } from '../../../../src/models/journal.js';
 import { UserType } from '../../../../src/models/user.js';
 import connectDB from '../../../../src/db.js';
 
 describe('Entry service tests', () => {
-  const NULL_CHECK_MESSAGE = 'EntryService function return should not be null in this test';
   let mockUser: HydratedDocument<UserType>;
   let mockJournal: HydratedDocument<JournalType>;
 
@@ -20,6 +18,7 @@ describe('Entry service tests', () => {
   });
 
   beforeEach(async () => {
+    jest.clearAllMocks();
     await mongoose.connection.dropDatabase();
     mockUser = await User.create({ fname: 'test', lname: 'test', email: 'testEmail@gmail.com' });
     mockJournal = await Journal.create({ user: mockUser.id });
@@ -29,132 +28,488 @@ describe('Entry service tests', () => {
     await mongoose.disconnect();
   });
 
-  it('gets no entries in an empty journal', async () => {
-    const entries = await EntryServices.getAllEntriesInJournal(mockJournal.id);
+  describe('Get Entry service operation tests', () => {
+    it('gets no entries in an empty journal', async () => {
+      const entries = await EntryServices.getAllEntriesInJournal(mockJournal.id);
 
-    expect(entries).toHaveLength(0);
-  });
+      expect(entries).toHaveLength(0);
+    });
 
-  it('returns empty list on error when getting all entries', async () => {
-    const entries = await EntryServices.getAllEntriesInJournal('bad id');
+    it('returns empty list on error when getting all entries', async () => {
+      const entries = await EntryServices.getAllEntriesInJournal('bad id');
 
-    expect(entries).toHaveLength(0);
-  });
+      expect(entries).toHaveLength(0);
+    });
 
-  it('gets all entries in a journal', async () => {
-    const mockEntry1 = new Entry({ journal: mockJournal.id, content: 'mock content' });
-    const mockEntry2 = new Entry({ journal: mockJournal.id, content: 'mock content' });
-    await mockEntry1.save();
-    await mockEntry2.save();
+    it('gets all entries in a journal', async () => {
+      const mockEntry1 = new Entry({ journal: mockJournal.id, content: 'mock content' });
+      const mockEntry2 = new Entry({ journal: mockJournal.id, content: 'mock content' });
+      await mockEntry1.save();
+      await mockEntry2.save();
 
-    const entries = await EntryServices.getAllEntriesInJournal(mockJournal.id);
+      const entries = await EntryServices.getAllEntriesInJournal(mockJournal.id);
 
-    expect(entries).toHaveLength(2);
-  });
+      expect(entries).toHaveLength(2);
+    });
 
-  it('gets entries from only one journal', async () => {
-    const mockJournal2 = new Journal({ user: mockUser.id });
-    const mockEntry1 = new Entry({ journal: mockJournal.id, content: 'mock content' });
-    const mockEntry2 = new Entry({ journal: mockJournal2.id, content: 'mock content' });
-    await mockEntry1.save();
-    await mockEntry2.save();
+    it('gets entries from only one journal', async () => {
+      const mockJournal2 = new Journal({ user: mockUser.id });
+      const mockEntry1 = new Entry({ journal: mockJournal.id, content: 'mock content' });
+      const mockEntry2 = new Entry({ journal: mockJournal2.id, content: 'mock content' });
+      await mockEntry1.save();
+      await mockEntry2.save();
 
-    const entries1 = await EntryServices.getAllEntriesInJournal(mockJournal.id);
-    const entries2 = await EntryServices.getAllEntriesInJournal(mockJournal2.id);
+      const entries1 = await EntryServices.getAllEntriesInJournal(mockJournal.id);
+      const entries2 = await EntryServices.getAllEntriesInJournal(mockJournal2.id);
 
-    expect(entries1).toHaveLength(1);
-    expect(entries2).toHaveLength(1);
-  });
+      expect(entries1).toHaveLength(1);
+      expect(entries2).toHaveLength(1);
+    });
 
-  it('gets Entry by entryId populated with EntryAnalysis and EntryConversation', async () => {
-    const mockEntry = new Entry({ journal: mockJournal.id, content: 'mock content' });
-    const mockAnalysis = new EntryAnalysis({ entry: mockEntry, analysis_content: 'test content', created_at: new Date(0), updated_at: new Date(0) });
-    const mockConversation = new EntryConversation({ entry: mockEntry, messages: [] });
-    mockEntry.analysis = mockAnalysis.id;
-    mockEntry.conversation = mockConversation.id;
-    await mockAnalysis.save();
-    await mockConversation.save();
-    await mockEntry.save();
+    it('gets Entry by entryId populated with EntryAnalysis and EntryConversation', async () => {
+      const mockEntry = new Entry({ journal: mockJournal.id, content: 'mock content' });
+      const mockAnalysis = new EntryAnalysis({ entry: mockEntry, analysis_content: 'test content', created_at: new Date(0), updated_at: new Date(0) });
+      const mockConversation = new EntryConversation({ entry: mockEntry, messages: [] });
+      mockEntry.analysis = mockAnalysis.id;
+      mockEntry.conversation = mockConversation.id;
+      await mockAnalysis.save();
+      await mockConversation.save();
+      await mockEntry.save();
 
-    const sut = await EntryServices.getPopulatedEntry(mockEntry.id);
+      const sut = await EntryServices.getPopulatedEntry(mockEntry.id);
 
-    if (sut === null) {
-      expect(NULL_CHECK_MESSAGE).toBe(false);
-      return;
-    }
-    expect(sut.id).toBe(mockEntry.id);
-    expect(sut.analysis.entry.toString()).toBe(mockEntry.id);
-    expect(sut.analysis.analysis_content).toBe('test content');
-    expect(sut.analysis.created_at).toBeDefined();
-    expect(sut.analysis.updated_at).toBeDefined();
-    expect(sut.conversation.entry.toString()).toBe(mockEntry.id);
-    expect(sut.conversation.messages).toBeDefined();
-  });
+      expect(sut!.id).toBe(mockEntry.id);
+      expect(sut!.analysis.entry.toString()).toBe(mockEntry.id);
+      expect(sut!.analysis.analysis_content).toBe('test content');
+      expect(sut!.analysis.created_at).toBeDefined();
+      expect(sut!.analysis.updated_at).toBeDefined();
+      expect(sut!.conversation.entry.toString()).toBe(mockEntry.id);
+      expect(sut!.conversation.messages).toBeDefined();
+    });
 
-  it('gets EntryAnalysis by entryId populated with Entry', async () => {
-    const mockEntry = new Entry({ journal: mockJournal.id, content: 'mock content' });
-    const mockAnalysis = new EntryAnalysis({ entry: mockEntry, analysis_content: 'test content', created_at: new Date(0), updated_at: new Date(0) });
-    mockEntry.analysis = mockAnalysis.id;
-    await mockAnalysis.save();
-    await mockEntry.save();
+    it('gets EntryAnalysis by entryId entry populated with Entry', async () => {
+      const mockEntry = new Entry({ journal: mockJournal.id, content: 'mock content' });
+      const mockAnalysis = new EntryAnalysis({ entry: mockEntry, analysis_content: 'test content', created_at: new Date(0), updated_at: new Date(0) });
+      mockEntry.analysis = mockAnalysis.id;
+      await mockAnalysis.save();
+      await mockEntry.save();
 
-    const sut = await EntryServices.getPopulatedEntryAnalysis(mockEntry.id);
-    if (sut === null) {
-      expect(NULL_CHECK_MESSAGE).toBe(false);
-      return;
-    }
+      const sut = await EntryServices.getPopulatedEntryAnalysis(mockEntry.id);
 
-    expect(sut.id).toBe(mockAnalysis.id);
-    expect(sut.entry.content).toBe('mock content');
-    expect(sut.entry.journal.toString()).toBe(mockJournal.id);
-  });
+      expect(sut!.id).toBe(mockAnalysis.id);
+      expect(sut!.entry.content).toBe('mock content');
+      expect(sut!.entry.journal.toString()).toBe(mockJournal.id);
+    });
 
-  it('returns null on error when getting populated EntryAnalysis', async () => {
-    const sut = await EntryServices.getPopulatedEntryAnalysis('bad id');
+    it('returns null on error when getting populated EntryAnalysis', async () => {
+      const sut = await EntryServices.getPopulatedEntryAnalysis('bad id');
     
-    expect(sut).toBeNull();
-  });
+      expect(sut).toBeNull();
+    });
 
-  it('gets EntryConversation by entryId', async () => {
-    const mockEntry = new Entry({ journal: mockJournal.id, content: 'mock content' });
-    const mockConversation = new EntryConversation({ entry: mockEntry, messages: [] });
-    await mockConversation.save();
-    await mockEntry.save();
+    it('gets EntryConversation by entryId', async () => {
+      const mockEntry = new Entry({ journal: mockJournal.id, content: 'mock content' });
+      const mockConversation = new EntryConversation({ entry: mockEntry, messages: [] });
+      await mockConversation.save();
+      await mockEntry.save();
 
-    const sut = await EntryServices.getEntryConversation(mockEntry.id);
-    if (sut === null) {
-      expect(NULL_CHECK_MESSAGE).toBe(false);
-      return;
-    }
+      const sut = await EntryServices.getEntryConversation(mockEntry.id);
 
-    expect(sut.id).toBe(mockConversation.id);
-  });
+      expect(sut!.id).toBe(mockConversation.id);
+    });
 
-  it('returns null on error when getting EntryConversation', async () => {
-    const sut = await EntryServices.getEntryConversation('bad id');
+    it('returns null on error when getting EntryConversation', async () => {
+      const sut = await EntryServices.getEntryConversation('bad id');
     
-    expect(sut).toBeNull();
+      expect(sut).toBeNull();
+    });
   });
 
-  it('creates entries with valid journal id and content', async () => {
-    const mockEntryContent: EntryType = {
-      journal: mockJournal.id,
-      content: 'mock content',
-    };
+  describe('Create operation Entry service tests', () => {
+    it('creates Entry with valid journal id, config id, and content', async () => {
+      const mockEntryContent = {
+        content: 'mock content',
+      };
+      const mockConfig = await Config.create({ model: {} });
+      jest.spyOn(EntryAnalysis.prototype, 'getAnalysisContent').mockResolvedValue(undefined);
 
-    const sut = await EntryServices.createEntry(mockJournal.id, mockEntryContent);
-    if (sut === null) {
-      expect(NULL_CHECK_MESSAGE).toBe(false);
-      return;
-    }
+      const { errMessage, entry: sut } = await EntryServices.createEntry(mockJournal.id, mockConfig.id, mockEntryContent);
+      const testAnalysis = await EntryAnalysis.findById(sut.analysis);
 
-    expect(sut.title).toBe('Untitled');
-    expect(sut.journal.toString()).toBe(mockJournal.id);
-    expect(sut.content).toBe('mock content');
-    expect(sut.tags).toStrictEqual([]);
-    expect(sut.analysis).toBeUndefined();
+      expect(errMessage).toBeUndefined();
+      expect(sut.title).toBe('Untitled');
+      expect(sut.journal.toString()).toBe(mockJournal.id);
+      expect(sut.content).toBe('mock content');
+      expect(sut.tags).toStrictEqual([]);
+      expect(sut.analysis!.toString()).toBe(testAnalysis!.id);
+      expect(testAnalysis!.analysis_content).toBe('Analysis not available');
+    });
+
+    it('creates Entry with valid journal id, config id, and content with analysis returned', async () => {
+      const mockEntryContent = {
+        content: 'mock content',
+      };
+      const mockConfig = await Config.create({ model: {} });
+      const mockAnalysisContent = {
+        title: 'Mock Title',
+        mood: 'mock mood',
+        tags: ['test', 'mock'],
+        analysis_content: 'mock analysis content',
+      };
+      jest.spyOn(EntryAnalysis.prototype, 'getAnalysisContent').mockResolvedValue(mockAnalysisContent);
+
+      const { errMessage, entry: sut } = await EntryServices.createEntry(mockJournal.id, mockConfig.id, mockEntryContent);
+      const testAnalysis = await EntryAnalysis.findById(sut.analysis);
+
+      expect(errMessage).toBeUndefined();
+      expect(sut.title).toBe(mockAnalysisContent.title);
+      expect(sut.journal.toString()).toBe(mockJournal.id);
+      expect(sut.mood).toBe(mockAnalysisContent.mood);
+      expect(sut.content).toBe('mock content');
+      expect(sut.tags).toStrictEqual(mockAnalysisContent.tags);
+      expect(sut.analysis!.toString()).toBe(testAnalysis!.id);
+      expect(testAnalysis!.analysis_content).toBe(mockAnalysisContent.analysis_content);
+    });
+
+    it('returns error message when getting analysis content throws error', async () => {
+      const mockEntryContent = {
+        journal: mockJournal.id,
+        content: 'mock content',
+      };
+      const mockConfig = await Config.create({ model: {} });
+      jest.spyOn(EntryAnalysis.prototype, 'getAnalysisContent').mockRejectedValue(new Error('test error message'));
+
+      const { errMessage, entry: sut } = await EntryServices.createEntry(mockJournal.id, mockConfig.id, mockEntryContent);
+      const testAnalysis = await EntryAnalysis.findById(sut.analysis);
+
+      expect(errMessage).toBe('test error message');
+      expect(sut.title).toBe('Untitled');
+      expect(sut.journal.toString()).toBe(mockJournal.id);
+      expect(sut.mood).toBeUndefined();
+      expect(sut.content).toBe('mock content');
+      expect(sut.tags).toStrictEqual([]);
+      expect(sut.analysis!.toString()).toBe(testAnalysis!.id);
+      expect(testAnalysis!.analysis_content).toBe('Analysis not available');
+    });
+
+    it('creates and saves EntryConversation with valid input', async () => {
+      const mockEntry = new Entry({ journal: mockJournal.id, content: 'mock content' });
+      const mockEntryAnalysis = await EntryAnalysis.create({ entry: mockEntry.id });
+      mockEntry.analysis = mockEntryAnalysis.id;
+      await mockEntry.save();
+      const mockConfig = await Config.create({ model: {} });
+      const mockMessageData = {
+        messages: [
+          {
+            message_content: 'test message',
+            llm_response: 'mock llm response'
+          },
+        ]
+      };
+      const mockLlmContent = 'mock llm chat response';
+      jest.spyOn(EntryConversation.prototype, 'getChatContent').mockResolvedValue(mockLlmContent);
+    
+      const sut = await EntryServices.createEntryConversation(
+        mockEntry.id,
+        mockConfig.id,
+        mockMessageData
+      );
+
+      expect(sut.entry.toString()).toBe(mockEntry.id);
+      expect(sut.messages!).toHaveLength(1);
+      expect(sut.messages![0].message_content).toBe(mockMessageData.messages[0].message_content);
+      expect(sut.messages![0].llm_response).toBe(mockLlmContent);
+    });
+
+    it('throws error on missing entry when creating EntryConversation', async () => {
+      const nonexistentEntry = new Entry({ journal: mockJournal.id, content: 'mock content' });
+      const mockConfig = new Config({ model: {} });
+      const mockMessageData = {
+        messages: [
+          {
+            message_content: 'test message',
+            llm_response: 'mock llm response'
+          },
+        ]
+      };
+    
+      await expect(EntryServices.createEntryConversation(
+        nonexistentEntry.id,
+        mockConfig.id,
+        mockMessageData
+      )).rejects.toThrow('Entry not found.');
+    });
+
+    it('throws error on missing entry.analysis when creating EntryConversation', async () => {
+      const mockEntry = new Entry({ journal: mockJournal.id, content: 'mock content' });
+      await mockEntry.save();
+      const mockConfig = new Config({ model: {} });
+      const mockMessageData = {
+        messages: [
+          {
+            message_content: 'test message',
+            llm_response: 'mock llm response'
+          },
+        ]
+      };
+    
+      await expect(EntryServices.createEntryConversation(
+        mockEntry.id,
+        mockConfig.id,
+        mockMessageData
+      )).rejects.toThrow('Entry analysis not found.');
+    });
+
+    it('throws error when new EntryConversation has empty messages', async () => {
+      const mockEntry = new Entry({ journal: mockJournal.id, content: 'mock content' });
+      const mockEntryAnalysis = await EntryAnalysis.create({ entry: mockEntry.id });
+      mockEntry.analysis = mockEntryAnalysis.id;
+      await mockEntry.save();
+      const mockConfig = new Config({ model: {} });
+      const mockMessageData = {
+        messages: [
+        ]
+      };
+    
+      await expect(EntryServices.createEntryConversation(
+        mockEntry.id,
+        mockConfig.id,
+        mockMessageData
+      )).rejects.toThrow('No message to get completion for.');
+    });
+
+    it('does not update EntryConversation if llm response is empty', async () => {
+      const mockEntry = new Entry({ journal: mockJournal.id, content: 'mock content' });
+      const mockEntryAnalysis = await EntryAnalysis.create({ entry: mockEntry.id });
+      mockEntry.analysis = mockEntryAnalysis.id;
+      await mockEntry.save();
+      const mockConfig = await Config.create({ model: {} });
+      const mockMessageData = {
+        messages: [
+          {
+            message_content: 'test message',
+            llm_response: 'mock llm response'
+          },
+        ]
+      };
+      const mockLlmContent = '';
+      jest.spyOn(EntryConversation.prototype, 'getChatContent').mockResolvedValue(mockLlmContent);
+    
+      const sut = await EntryServices.createEntryConversation(
+        mockEntry.id,
+        mockConfig.id,
+        mockMessageData
+      );
+
+      expect(sut.entry.toString()).toBe(mockEntry.id);
+      expect(sut.messages!).toHaveLength(1);
+      expect(sut.messages![0].message_content).toBe(mockMessageData.messages[0].message_content);
+      expect(sut.messages![0].llm_response).toBe(mockMessageData.messages[0].llm_response);
+    });
   });
 
-  it('creates entries', async () => { });
+  describe('updateEntry tests', () => {
+    it('updates Entry with valid journal id, config id, and content', async () => {
+      const mockEntry = new Entry({ journal: mockJournal.id, content: 'mock content' });
+      const mockEntryAnalysis = await EntryAnalysis.create({ entry: mockEntry.id });
+      mockEntry.analysis = mockEntryAnalysis.id;
+      await mockEntry.save();
+      const updateContent = {
+        content: 'mock content',
+        title: 'mock title'
+      };
+      const mockConfig = await Config.create({ model: {} });
+      jest.spyOn(EntryAnalysis.prototype, 'getAnalysisContent').mockResolvedValue(undefined);
+  
+      const { errMessage, entry: sut } = await EntryServices.updateEntry(mockEntry.id, mockConfig.id, updateContent);
+      const testAnalysis = await EntryAnalysis.findById(sut.analysis);
+  
+      expect(errMessage).toBeUndefined();
+      expect(sut.title).toBe('Untitled');
+      expect(sut.journal.toString()).toBe(mockJournal.id);
+      expect(sut.content).toBe('mock content');
+      expect(sut.tags).toStrictEqual([]);
+      expect(sut.analysis!.toString()).toBe(testAnalysis!.id);
+      expect(testAnalysis!.analysis_content).toBe('Analysis not available');
+    });
+  
+    it('updates Entry with valid journal id, config id, and content with analysis returned', async () => {
+      const mockEntry = new Entry({ journal: mockJournal.id, content: 'mock content' });
+      const mockEntryAnalysis = await EntryAnalysis.create({ entry: mockEntry.id });
+      mockEntry.analysis = mockEntryAnalysis.id;
+      await mockEntry.save();
+      const updateContent = {
+        content: 'mock content',
+        title: 'mock title'
+      };
+      const mockConfig = await Config.create({ model: {} });
+      const mockAnalysisContent = {
+        title: 'Mock Title',
+        mood: 'mock mood',
+        tags: ['test', 'mock'],
+        analysis_content: 'mock analysis content',
+      };
+      jest.spyOn(EntryAnalysis.prototype, 'getAnalysisContent').mockResolvedValue(mockAnalysisContent);
+  
+      const { errMessage, entry: sut } = await EntryServices.updateEntry(mockEntry.id, mockConfig.id, updateContent);
+      const testAnalysis = await EntryAnalysis.findById(sut.analysis);
+  
+      expect(errMessage).toBeUndefined();
+      expect(sut.title).toBe(mockAnalysisContent.title);
+      expect(sut.journal.toString()).toBe(mockJournal.id);
+      expect(sut.mood).toBe(mockAnalysisContent.mood);
+      expect(sut.content).toBe('mock content');
+      expect(sut.tags).toStrictEqual(mockAnalysisContent.tags);
+      expect(sut.analysis!.toString()).toBe(testAnalysis!.id);
+      expect(testAnalysis!.analysis_content).toBe(mockAnalysisContent.analysis_content);
+    });
+  
+    it('returns error message when getting analysis content throws error', async () => {
+      const mockEntry = new Entry({ journal: mockJournal.id, content: 'mock content' });
+      const mockEntryAnalysis = await EntryAnalysis.create({ entry: mockEntry.id });
+      mockEntry.analysis = mockEntryAnalysis.id;
+      await mockEntry.save();
+      const updateContent = {
+        content: 'mock content',
+        title: 'mock title'
+      };
+      const mockConfig = await Config.create({ model: {} });
+      jest.spyOn(EntryAnalysis.prototype, 'getAnalysisContent').mockRejectedValue(new Error('test error message'));
+  
+      const { errMessage, entry: sut } = await EntryServices.updateEntry(mockEntry.id, mockConfig.id, updateContent);
+      const testAnalysis = await EntryAnalysis.findById(sut.analysis);
+  
+      expect(errMessage).toBe('test error message');
+      expect(sut.title).toBe('Untitled');
+      expect(sut.journal.toString()).toBe(mockJournal.id);
+      expect(sut.mood).toBeUndefined();
+      expect(sut.content).toBe('mock content');
+      expect(sut.tags).toStrictEqual([]);
+      expect(sut.analysis!.toString()).toBe(testAnalysis!.id);
+      expect(testAnalysis!.analysis_content).toBe('Analysis not available');
+    });
 
+    it('updates title when content is empty', async () => {
+      const mockEntry = new Entry({ journal: mockJournal.id, content: 'mock content' });
+      const mockEntryAnalysis = await EntryAnalysis.create({ entry: mockEntry.id });
+      mockEntry.analysis = mockEntryAnalysis.id;
+      await mockEntry.save();
+      const updateContent = {
+        title: 'mock title'
+      };
+      const mockConfig = await Config.create({ model: {} });
+  
+      const { errMessage, entry: sut } = await EntryServices.updateEntry(mockEntry.id, mockConfig.id, updateContent);
+      const testAnalysis = await EntryAnalysis.findById(sut.analysis);
+  
+      expect(errMessage).toBeUndefined();
+      expect(sut.title).toBe(updateContent.title);
+      expect(sut.journal.toString()).toBe(mockJournal.id);
+      expect(sut.mood).toBeUndefined();
+      expect(sut.content).toBe('mock content');
+      expect(sut.tags).toStrictEqual([]);
+      expect(sut.analysis!.toString()).toBe(testAnalysis!.id);
+      expect(testAnalysis!.analysis_content).toBe('Analysis not available');
+    });
+  });
+
+  describe('Update EntryAnalysis tests', () => {
+    it('updates EntryAnalysis', async () => {
+      const mockEntry = new Entry({ journal: mockJournal.id, content: 'mock content' });
+      const mockEntryAnalysis = await EntryAnalysis.create({ entry: mockEntry.id });
+      mockEntry.analysis = mockEntryAnalysis.id;
+      await mockEntry.save();
+      const updateContent = {
+        analysis_content: 'llm updated content',
+        title: 'llm updated title',
+        mood: 'llm updated mood',
+        tags: ['new tag'],
+      };
+      const mockConfig = await Config.create({ model: {} });
+      jest.spyOn(EntryAnalysis.prototype, 'getAnalysisContent').mockResolvedValue(updateContent);
+  
+      const { errMessage, entry: sut } = await EntryServices.updateEntryAnalysis(mockEntry.id, mockConfig.id);
+      const testAnalysis = await EntryAnalysis.findById(sut.analysis);
+  
+      expect(errMessage).toBeUndefined();
+      expect(sut.title).toBe(updateContent.title);
+      expect(sut.journal.toString()).toBe(mockJournal.id);
+      expect(sut.content).toBe('mock content');
+      expect(sut.tags).toStrictEqual(updateContent.tags);
+      expect(sut.analysis!.toString()).toBe(testAnalysis!.id);
+      expect(testAnalysis!.analysis_content).toBe(updateContent.analysis_content);
+      expect(sut.mood).toBe(updateContent.mood);
+    });
+  });
+
+  describe('Update EntryConversation tests', () => {
+    it('updates EntryConversation with valid input', async () => {
+      const mockEntry = new Entry({ journal: mockJournal.id, content: 'mock content' });
+      const mockAnalysis = new EntryAnalysis({ entry: mockEntry, analysis_content: 'test content', created_at: new Date(0), updated_at: new Date(0) });
+      const mockChat = new EntryConversation({ entry: mockEntry, messages: [] });
+      await mockChat.save();
+      await mockAnalysis.save();
+      await mockEntry.save();
+      const mockConfig = await Config.create({ model: {} });
+      const mockMessageData = {
+        messages: [
+          {
+            message_content: 'message_content',
+            llm_response: 'llm_response',
+          },
+        ]
+      };
+      const mockLlmResponse = 'test chat llm response';
+      jest.spyOn(EntryConversation.prototype, 'getChatContent').mockResolvedValue(mockLlmResponse);
+
+      const sut = await EntryServices.updateEntryConversation(mockChat.id, mockConfig.id, mockMessageData);
+
+      expect(sut.messages![0].message_content).toBe('message_content');
+      expect(sut.messages![0].llm_response).toBe('test chat llm response');
+    });
+  });
+
+  describe('Delete Entry tests', () => {
+    it('deletes Entry, EntryAnalysis, and EntryConversation by ID', async () => {
+      const mockEntry = new Entry({ journal: mockJournal.id, content: 'mock content' });
+      const mockAnalysis = new EntryAnalysis({ entry: mockEntry, analysis_content: 'test content', created_at: new Date(0), updated_at: new Date(0) });
+      const mockChat = new EntryConversation({ entry: mockEntry, messages: [] });
+      await mockChat.save();
+      await mockAnalysis.save();
+      await mockEntry.save();
+
+      await EntryServices.deleteEntry(mockEntry.id);
+
+      await expect(Entry.findById(mockEntry.id)).resolves.toBeNull();
+      await expect(EntryAnalysis.findById(mockAnalysis.id)).resolves.toBeNull();
+      await expect(EntryConversation.findById(mockChat.id)).resolves.toBeNull();
+    });
+
+    it('throws error if entry not found', async () => {
+      const mockEntry = new Entry({ journal: mockJournal.id, content: 'mock content' });
+      const mockAnalysis = new EntryAnalysis({ entry: mockEntry, analysis_content: 'test content', created_at: new Date(0), updated_at: new Date(0) });
+      const mockChat = new EntryConversation({ entry: mockEntry, messages: [] });
+      await mockChat.save();
+      await mockAnalysis.save();
+
+      await expect(EntryServices.deleteEntry(mockEntry.id)).rejects.toThrow('Entry not found.');
+      await expect(EntryAnalysis.findById(mockAnalysis.id)).resolves.toBeDefined();
+      await expect(EntryConversation.findById(mockChat.id)).resolves.toBeDefined();
+    });
+
+    it('aborts delete transcation on error', async () => {
+      const mockEntry = new Entry({ journal: mockJournal.id, content: 'mock content' });
+      const mockAnalysis = new EntryAnalysis({ entry: mockEntry, analysis_content: 'test content', created_at: new Date(0), updated_at: new Date(0) });
+      const mockChat = new EntryConversation({ entry: mockEntry, messages: [] });
+      await mockChat.save();
+      await mockAnalysis.save();
+      await mockEntry.save();
+      jest.spyOn(EntryAnalysis, 'deleteMany').mockRejectedValue(new Error('test transaction atomicity'));
+
+      await expect(EntryServices.deleteEntry(mockEntry.id)).rejects.toThrow('test transaction atomicity');
+      await expect(Entry.findById(mockEntry.id)).resolves.toBeDefined();
+      await expect(EntryAnalysis.findById(mockAnalysis.id)).resolves.toBeDefined();
+      await expect(EntryConversation.findById(mockChat.id)).resolves.toBeDefined();
+    });
+  });
 });

--- a/backend/tests/models/services/entry/entry.test.ts
+++ b/backend/tests/models/services/entry/entry.test.ts
@@ -479,7 +479,7 @@ describe('Entry service tests', () => {
       await expect(EntryConversation.findById(mockChat.id)).resolves.toBeDefined();
     });
 
-    it('aborts delete transcation on error', async () => {
+    it('aborts delete transaction on error', async () => {
       const mockEntry = new Entry({ journal: mockJournal.id, content: 'mock content' });
       const mockAnalysis = new EntryAnalysis({ entry: mockEntry, analysis_content: 'test content', created_at: new Date(0), updated_at: new Date(0) });
       const mockChat = new EntryConversation({ entry: mockEntry, messages: [] });

--- a/backend/tests/models/services/entry/entry.test.ts
+++ b/backend/tests/models/services/entry/entry.test.ts
@@ -35,12 +35,6 @@ describe('Entry service tests', () => {
       expect(entries).toHaveLength(0);
     });
 
-    it('returns empty list on error when getting all entries', async () => {
-      const entries = await EntryServices.getAllEntriesInJournal('bad id');
-
-      expect(entries).toHaveLength(0);
-    });
-
     it('gets all entries in a journal', async () => {
       const mockEntry1 = new Entry({ journal: mockJournal.id, content: 'mock content' });
       const mockEntry2 = new Entry({ journal: mockJournal.id, content: 'mock content' });
@@ -101,12 +95,6 @@ describe('Entry service tests', () => {
       expect(sut!.entry.journal.toString()).toBe(mockJournal.id);
     });
 
-    it('returns null on error when getting populated EntryAnalysis', async () => {
-      const sut = await EntryServices.getPopulatedEntryAnalysis('bad id');
-    
-      expect(sut).toBeNull();
-    });
-
     it('gets EntryConversation by entryId', async () => {
       const mockEntry = new Entry({ journal: mockJournal.id, content: 'mock content' });
       const mockConversation = new EntryConversation({ entry: mockEntry, messages: [] });
@@ -116,12 +104,6 @@ describe('Entry service tests', () => {
       const sut = await EntryServices.getEntryConversation(mockEntry.id);
 
       expect(sut!.id).toBe(mockConversation.id);
-    });
-
-    it('returns null on error when getting EntryConversation', async () => {
-      const sut = await EntryServices.getEntryConversation('bad id');
-    
-      expect(sut).toBeNull();
     });
   });
 


### PR DESCRIPTION
Note: This PR removes the changes not related to entry services in, and will close it #192
# This PR contains the following changes:
- Entry controller refactoring, moving CRUD operations into entry service file
- Updates jest setup script to deploy memory-mongodb as replica set to support delete unit tests

## Entry Controller
The entry controller was a very large file and difficult to test as it combined code for performing CRUD operations on entries with Express error handling, request parsing, and response creation. This PR made the following changes:
- Moved code for performing create, update, and deletes on Entry, EntryConversation, and EntryAnalysis into a service layer (/models/services/entry/entry.ts)
- Adds unit tests for entry service module
- Creates function verifyJournalExists for sharing operation across controller functions
- Adds custom types UpdateEntryRequestBody and UpdateChatRequestBody for enforcing types for request.body for different controller functions

## Jest setup script
To support deletes, I had to deploy mongodb as a replica set rather than a standalone instance. This works, but occasionally I get a ECONNRESET error on cleanup. This doesn't affect any of the unit tests, and only occurs after all of them have run. I think it may have something to do with Jest closing before all of the replica instances close, but I haven't confirmed it. This error doesn't appear to break anything in the test suite, and deploying memory mongodb as a replica set is necessary to support deletes.