### PR TITLE
chore: add test env vars

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,6 +16,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment: test
 
     steps:
       - uses: actions/checkout@v4
@@ -32,6 +33,12 @@ jobs:
       - name: Install dependencies
         working-directory: backend
         run: npm ci
+
+      - name: Set up .env file
+        working-directory: backend
+        run: |
+          echo "${{ secrets.TEST_ENV_VARS }}" > .env
+        shell: bash
 
       - name: Run linter
         working-directory: backend


### PR DESCRIPTION
This adds a step to node.js.yml action to load environment variables from GitHub secrets test environment resolving the CI fail on the `Run tests` step.