### PR TITLE
fix: allow multi-line secret

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -37,7 +37,9 @@ jobs:
       - name: Set up .env file
         working-directory: backend
         run: |
-          echo "${{ secrets.TEST_ENV_VARS }}" > .env
+          cat << 'EOF' > .env
+          ${{ secrets.TEST_ENV_VARS }}
+          EOF
         shell: bash
 
       - name: Run linter

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,6 +16,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment: test
 
     steps:
       - uses: actions/checkout@v4
@@ -32,6 +33,12 @@ jobs:
       - name: Install dependencies
         working-directory: backend
         run: npm ci
+
+      - name: Set up .env file
+        working-directory: backend
+        run: |
+          echo "${{ secrets.TEST_ENV_VARS }}" > .env
+        shell: bash
 
       - name: Run linter
         working-directory: backend


### PR DESCRIPTION
`Set up .env file` step of node.js.yml action could not create multi-line .env file. Multi-line file can be created using Heredoc.