### PR TITLE
test: add entry controller tests

### DIFF
--- a/backend/src/controllers/entry/entry.ts
+++ b/backend/src/controllers/entry/entry.ts
@@ -158,7 +158,7 @@ export const getEntryAnalysis = async (
     return next(new ExpressError('Entry analysis not found.', 404));
   }
 
-  res.status(200).json(entryAnalysis.toObject());
+  res.status(200).json(entryAnalysis);
 };
 
 /**

--- a/backend/src/controllers/entry/entry.ts
+++ b/backend/src/controllers/entry/entry.ts
@@ -204,7 +204,7 @@ export const getEntryConversation = async (req: Request, res: Response) => {
 
   const response = await EntryServices.getEntryConversation(entryId);
   const entryConversation = response
-    ? { ...response.toObject(), chatId: response.id }
+    ? { ...response, chatId: response.id }
     : {};
 
   res.status(200).json(entryConversation);
@@ -224,13 +224,12 @@ export const createEntryConversation = async (
   try {
     const configId = await verifyJournalExists(journalId);
 
-    const response = await EntryServices.createEntryConversation(
+    const entryConversation = await EntryServices.createEntryConversation(
       entryId,
       configId,
       messageData
     );
 
-    const entryConversation = response ? response.toObject() : {};
     req.flash('success', 'Successfully created conversation.');
     res.status(201).json({ ...entryConversation, flash: req.flash() });
   } catch (error) {
@@ -253,7 +252,11 @@ export const updateEntryConversation = async (
     const configId = await verifyJournalExists(journalId);
 
     const response = await EntryServices.updateEntryConversation(chatId, configId, messageData);
-    res.status(200).json({ ...response.toObject(), flash: req.flash() });
+
+    /* FIXME: No flash messages are attached to prevent over-displaying--this
+     * seems like something the frontend should handle 
+     */
+    res.status(200).json({ ...response, flash: req.flash() });
   } catch (error) {
     return next(error);
   }

--- a/backend/src/controllers/entry/entry.ts
+++ b/backend/src/controllers/entry/entry.ts
@@ -31,7 +31,7 @@ export const getAllEntries = async (
 ) => {
   const { journalId } = req.params;
 
-  const entries = await EntryServices.getAllEntriesInJournal(journalId);
+  const entries = await EntryServices.getAllEntries(journalId);
 
   if (entries.length === 0) {
     req.flash('info', 'Submit your first entry to get started.');

--- a/backend/src/controllers/entry/entry.ts
+++ b/backend/src/controllers/entry/entry.ts
@@ -183,7 +183,7 @@ export const updateEntryAnalysis = async (
     res
       .status(200)
       .json({
-        ...entryAnalysis.toObject(),
+        ...entryAnalysis,
         entry: entry.toObject(),
         flash: req.flash(),
       });

--- a/backend/src/models/services/entry/entry.ts
+++ b/backend/src/models/services/entry/entry.ts
@@ -24,7 +24,7 @@ interface EntryResponse {
  * @param journalId Journal._id as string
  * @returns array of documents in journal with journalId
  */
-export async function getAllEntriesInJournal(
+export async function getAllEntries(
   journalId: string
 ): Promise<HydratedDocument<EntryType>[]> {
   return await Entry.find({ journal: journalId });

--- a/backend/tests/controllers/entry/entry.test.ts
+++ b/backend/tests/controllers/entry/entry.test.ts
@@ -16,7 +16,7 @@ jest.mock('../../../src/utils/ExpressError.js');
 
 // Consolidated mock for services
 jest.mock('../../../src/models/services/entry/entry.js', () => ({
-  getAllEntriesInJournal: jest.fn(),
+  getAllEntries: jest.fn(),
   createEntry: jest.fn(),
 }));
 
@@ -53,7 +53,7 @@ describe('Entry Controller Tests', () => {
       
       const res = mockRes();
   
-      (EntryServices.getAllEntriesInJournal as jest.Mock).mockResolvedValue([
+      (EntryServices.getAllEntries as jest.Mock).mockResolvedValue([
         { title: 'Entry 1', content: 'Content 1' },
         { title: 'Entry 2', content: 'Content 2' }
       ]);
@@ -76,7 +76,7 @@ describe('Entry Controller Tests', () => {
       
       const res = mockRes();
   
-      (EntryServices.getAllEntriesInJournal as jest.Mock).mockResolvedValue([]);
+      (EntryServices.getAllEntries as jest.Mock).mockResolvedValue([]);
   
       await EntryController.getAllEntries(req, res);
   

--- a/backend/tests/controllers/entry/entry.test.ts
+++ b/backend/tests/controllers/entry/entry.test.ts
@@ -1,35 +1,35 @@
 import * as EntryController from '../../../src/controllers/entry/entry.js';
 import * as EntryServices from '../../../src/models/services/entry/entry.js';
-import { NextFunction, Request, Response } from 'express';
+import * as Models from '../../../src/models/index.js';
+import { Request, Response } from 'express';
+import ExpressError from '../../../src/utils/ExpressError.js';
 
-// Mock all the service methods used in the controller
+jest.mock('../../../src/models/services/entry/entry.js', () => ({
+  createEntry: jest.fn(),
+}));
+jest.mock('../../../src/models/index.js', () => ({
+  Journal: {
+    findById: jest.fn(),
+  },
+}));
+jest.mock('../../../src/utils/ExpressError.js');
+
+// Consolidated mock for services
 jest.mock('../../../src/models/services/entry/entry.js', () => ({
   getAllEntriesInJournal: jest.fn(),
   createEntry: jest.fn(),
-  getPopulatedEntry: jest.fn(),
-  updateEntry: jest.fn(),
-  deleteEntry: jest.fn(),
-  getPopulatedEntryAnalysis: jest.fn(),
-  updateEntryAnalysis: jest.fn(),
-  getEntryConversation: jest.fn(),
-  createEntryConversation: jest.fn(),
-  updateEntryConversation: jest.fn(),
 }));
 
 const mockReq = () => {
   const flashStore: { [key: string]: string[] } = {};
-  return {
-    params: {},
-    body: {},
-    flash: jest.fn((key: string, value?: string) => {
-      if (value) {
-        if (!flashStore[key]) flashStore[key] = [];
-        flashStore[key].push(value);
-      } else {
-        return flashStore[key] || [];
-      }
-    }),
-  } as unknown as Request;
+  const req = {} as Partial<Request>;
+  req.params = {};
+  req.body = {};
+  req.flash = jest.fn((errorType?: string, message?: string) => {
+    if (errorType && message) flashStore[errorType] = [message];
+    return flashStore;
+  }) as never;
+  return req as Request;
 };
 
 const mockRes = () => {
@@ -39,9 +39,13 @@ const mockRes = () => {
   return res as Response;
 };
 
-const mockNext = () => jest.fn() as NextFunction;
+const mockNext = (): jest.Mock => jest.fn();
 
 describe('Entry Controller Tests', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   describe('getAllEntries', () => {
     it('should return entries with status 200 when entries exist', async () => {
       const req = mockReq();
@@ -62,25 +66,104 @@ describe('Entry Controller Tests', () => {
           { title: 'Entry 1', content: 'Content 1' },
           { title: 'Entry 2', content: 'Content 2' }
         ],
-        flash: []
+        flash: {},
       });
     });
-  
-    it('should flash a message if no entries found', async () => {
+  });
+
+  describe('createEntry', () => {
+    it('should create an entry successfully and return status 201', async () => {
       const req = mockReq();
       req.params.journalId = 'testJournalId';
-
+      req.body = {
+        title: 'Test Entry',
+        content: 'This is a test entry.',
+      };
+  
       const res = mockRes();
       const next = mockNext();
   
-      (EntryServices.getAllEntriesInJournal as jest.Mock).mockResolvedValue([]);
+      (Models.Journal.findById as jest.Mock).mockResolvedValue({
+        config: 'testConfigId',
+      });
   
-      await EntryController.getAllEntries(req, res);
+      (EntryServices.createEntry as jest.Mock).mockResolvedValue({
+        errMessage: null,
+        entry: {
+          toObject: jest.fn().mockReturnValue({
+            title: 'Test Entry',
+            content: 'This is a test entry.',
+          }),
+        },
+      });
   
-      expect(res.status).toHaveBeenCalledWith(200);
-      expect(res.json).toHaveBeenCalledWith({ entries: [], flash: [] });
-      expect(req.flash).toHaveBeenCalledWith('info', 'Submit your first entry to get started.');
+      await EntryController.createEntry(req, res, next);
+  
+      expect(req.flash).not.toHaveBeenCalledWith('info');
+      expect(res.status).toHaveBeenCalledWith(201);
+      expect(res.json).toHaveBeenCalledWith({
+        title: 'Test Entry',
+        content: 'This is a test entry.',
+        flash: {},
+      });
       expect(next).not.toHaveBeenCalled();
+    });
+  
+    it('should return a flash message and 201 status when there is an error message from service', async () => {
+      const req = mockReq();
+      req.params.journalId = 'testJournalId';
+      req.body = { title: 'Test Entry', content: 'This is a test entry.' };
+    
+      const res = mockRes();
+      const next = mockNext();
+    
+      (Models.Journal.findById as jest.Mock).mockResolvedValue({ config: 'testConfigId' });
+
+      (EntryServices.createEntry as jest.Mock).mockResolvedValue({
+        errMessage: 'Some warning.',
+        entry: { toObject: jest.fn().mockReturnValue({ title: 'Test Entry', content: 'This is a test entry.' }) },
+      });
+    
+      await EntryController.createEntry(req, res, next);
+    
+      expect(req.flash).toHaveBeenCalledWith('info', 'Some warning.');
+      expect(res.status).toHaveBeenCalledWith(201);
+      expect(res.json).toHaveBeenCalledWith({
+        title: 'Test Entry',
+        content: 'This is a test entry.',
+        flash: { info: ['Some warning.'] },
+      });
+    });
+  
+    it('should call next with an error if the journal is not found', async () => {
+      const req = mockReq();
+      req.params.journalId = 'testJournalId';
+  
+      const res = mockRes();
+      const next = mockNext();
+  
+      (Models.Journal.findById as jest.Mock).mockResolvedValue(null);
+      
+      await EntryController.createEntry(req, res, next);
+  
+      expect(next).toHaveBeenCalledWith(expect.any(ExpressError));
+    });
+  
+    it('should call next with an error if an exception occurs', async () => {
+      const req = mockReq();
+      req.params.journalId = 'testJournalId';
+  
+      const res = mockRes();
+      const next = mockNext();
+  
+      (Models.Journal.findById as jest.Mock).mockRejectedValue(
+        new Error('Database error')
+      );
+  
+      await EntryController.createEntry(req, res, next);
+  
+      expect(next).toHaveBeenCalledWith(expect.any(Error));
+      expect(next.mock.calls[0][0].message).toBe('Database error');
     });
   });
 });

--- a/backend/tests/controllers/entry/entry.test.ts
+++ b/backend/tests/controllers/entry/entry.test.ts
@@ -4,14 +4,12 @@ import * as Models from '../../../src/models/index.js';
 import { Request, Response } from 'express';
 import ExpressError from '../../../src/utils/ExpressError.js';
 
-jest.mock('../../../src/models/services/entry/entry.js', () => ({
-  createEntry: jest.fn(),
-}));
 jest.mock('../../../src/models/index.js', () => ({
   Journal: {
     findById: jest.fn(),
   },
 }));
+
 jest.mock('../../../src/utils/ExpressError.js');
 
 // Consolidated mock for services

--- a/backend/tests/controllers/entry/entry.test.ts
+++ b/backend/tests/controllers/entry/entry.test.ts
@@ -1,0 +1,86 @@
+import * as EntryController from '../../../src/controllers/entry/entry.js';
+import * as EntryServices from '../../../src/models/services/entry/entry.js';
+import { NextFunction, Request, Response } from 'express';
+
+// Mock all the service methods used in the controller
+jest.mock('../../../src/models/services/entry/entry.js', () => ({
+  getAllEntriesInJournal: jest.fn(),
+  createEntry: jest.fn(),
+  getPopulatedEntry: jest.fn(),
+  updateEntry: jest.fn(),
+  deleteEntry: jest.fn(),
+  getPopulatedEntryAnalysis: jest.fn(),
+  updateEntryAnalysis: jest.fn(),
+  getEntryConversation: jest.fn(),
+  createEntryConversation: jest.fn(),
+  updateEntryConversation: jest.fn(),
+}));
+
+const mockReq = () => {
+  const flashStore: { [key: string]: string[] } = {};
+  return {
+    params: {},
+    body: {},
+    flash: jest.fn((key: string, value?: string) => {
+      if (value) {
+        if (!flashStore[key]) flashStore[key] = [];
+        flashStore[key].push(value);
+      } else {
+        return flashStore[key] || [];
+      }
+    }),
+  } as unknown as Request;
+};
+
+const mockRes = () => {
+  const res = {} as Partial<Response>;
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res as Response;
+};
+
+const mockNext = () => jest.fn() as NextFunction;
+
+describe('Entry Controller Tests', () => {
+  describe('getAllEntries', () => {
+    it('should return entries with status 200 when entries exist', async () => {
+      const req = mockReq();
+      req.params.journalId = 'testJournalId';
+      
+      const res = mockRes();
+  
+      (EntryServices.getAllEntriesInJournal as jest.Mock).mockResolvedValue([
+        { title: 'Entry 1', content: 'Content 1' },
+        { title: 'Entry 2', content: 'Content 2' }
+      ]);
+  
+      await EntryController.getAllEntries(req, res);
+  
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        entries: [
+          { title: 'Entry 1', content: 'Content 1' },
+          { title: 'Entry 2', content: 'Content 2' }
+        ],
+        flash: []
+      });
+    });
+  
+    it('should flash a message if no entries found', async () => {
+      const req = mockReq();
+      req.params.journalId = 'testJournalId';
+
+      const res = mockRes();
+      const next = mockNext();
+  
+      (EntryServices.getAllEntriesInJournal as jest.Mock).mockResolvedValue([]);
+  
+      await EntryController.getAllEntries(req, res);
+  
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({ entries: [], flash: [] });
+      expect(req.flash).toHaveBeenCalledWith('info', 'Submit your first entry to get started.');
+      expect(next).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/tests/controllers/entry/entry.test.ts
+++ b/backend/tests/controllers/entry/entry.test.ts
@@ -69,6 +69,23 @@ describe('Entry Controller Tests', () => {
         flash: {},
       });
     });
+
+    it('should return a flash message when there are no entries', async () => {
+      const req = mockReq();
+      req.params.journalId = 'testJournalId';
+      
+      const res = mockRes();
+  
+      (EntryServices.getAllEntriesInJournal as jest.Mock).mockResolvedValue([]);
+  
+      await EntryController.getAllEntries(req, res);
+  
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        entries: [],
+        flash: { info: ['Submit your first entry to get started.'] },
+      });
+    });
   });
 
   describe('createEntry', () => {

--- a/backend/tests/controllers/entry/entry.test.ts
+++ b/backend/tests/controllers/entry/entry.test.ts
@@ -173,6 +173,22 @@ describe('Entry Controller Tests', () => {
   
       expect(next).toHaveBeenCalledWith(expect.any(ExpressError));
     });
+
+    it('should call next with an error if the journal config is not found', async () => {
+      const req = mockReq();
+      req.params.journalId = 'testJournalId';
+  
+      const res = mockRes();
+      const next = mockNext();
+  
+      (Models.Journal.findById as jest.Mock).mockResolvedValue({
+        config: null,
+      });
+      
+      await EntryController.createEntry(req, res, next);
+  
+      expect(next).toHaveBeenCalledWith(expect.any(ExpressError));
+    });
   
     it('should call next with an error if an exception occurs', async () => {
       const req = mockReq();

--- a/backend/tests/models/services/entry/entry.test.ts
+++ b/backend/tests/models/services/entry/entry.test.ts
@@ -30,7 +30,7 @@ describe('Entry service tests', () => {
 
   describe('Get Entry service operation tests', () => {
     it('gets no entries in an empty journal', async () => {
-      const entries = await EntryServices.getAllEntriesInJournal(mockJournal.id);
+      const entries = await EntryServices.getAllEntries(mockJournal.id);
 
       expect(entries).toHaveLength(0);
     });
@@ -41,7 +41,7 @@ describe('Entry service tests', () => {
       await mockEntry1.save();
       await mockEntry2.save();
 
-      const entries = await EntryServices.getAllEntriesInJournal(mockJournal.id);
+      const entries = await EntryServices.getAllEntries(mockJournal.id);
 
       expect(entries).toHaveLength(2);
     });
@@ -53,8 +53,8 @@ describe('Entry service tests', () => {
       await mockEntry1.save();
       await mockEntry2.save();
 
-      const entries1 = await EntryServices.getAllEntriesInJournal(mockJournal.id);
-      const entries2 = await EntryServices.getAllEntriesInJournal(mockJournal2.id);
+      const entries1 = await EntryServices.getAllEntries(mockJournal.id);
+      const entries2 = await EntryServices.getAllEntries(mockJournal2.id);
 
       expect(entries1).toHaveLength(1);
       expect(entries2).toHaveLength(1);


### PR DESCRIPTION
This PR tests the entry controller with unit tests. The initial commit sets up the test suite and adds unit tests for `getAllEntries`.