### PR TITLE
test: add access controller tests

### DIFF
--- a/backend/src/controllers/access/access.ts
+++ b/backend/src/controllers/access/access.ts
@@ -433,7 +433,7 @@ export const register = async (req: Request, res: Response, next: NextFunction) 
       password,
       title
     );
-    req.login(newUser, (err) => {
+    req.logIn(newUser, (err) => {
       if (err) return next(err);
 
       req.flash(

--- a/backend/src/controllers/access/access.ts
+++ b/backend/src/controllers/access/access.ts
@@ -1,4 +1,4 @@
-import * as AccessServices from '../../models/services/access.js';
+import * as AccessServices from '../../models/services/access/access.js';
 import { Journal, User } from '../../models/index.js';
 import { NextFunction, Request, Response } from 'express';
 import jwt, { JwtPayload } from 'jsonwebtoken';

--- a/backend/src/controllers/access/access.ts
+++ b/backend/src/controllers/access/access.ts
@@ -246,6 +246,8 @@ export const deleteItem = async (req: Request, res: Response, next: NextFunction
         )
       );
     }
+  } else {
+    return next(new ExpressError('Invalid deletion item.', 400));
   }
 };
 

--- a/backend/src/models/services/access/access.ts
+++ b/backend/src/models/services/access/access.ts
@@ -1,9 +1,9 @@
-import { Config, Entry, EntryAnalysis, EntryConversation, Journal, User } from '../index.js';
-import { ConfigType } from '../config.js';
-import ExpressError from '../../utils/ExpressError.js';
+import { Config, Entry, EntryAnalysis, EntryConversation, Journal, User } from '../../index.js';
+import { ConfigType } from '../../config.js';
+import ExpressError from '../../../utils/ExpressError.js';
 import { HydratedDocument } from 'mongoose';
-import { JournalType } from '../journal.js';
-import { UserType } from '../user.js';
+import { JournalType } from '../../journal.js';
+import { UserType } from '../../user.js';
 import crypto from 'crypto';
 
 /**

--- a/backend/tests/controllers/access/access.test.ts
+++ b/backend/tests/controllers/access/access.test.ts
@@ -1,5 +1,6 @@
 import * as AccessController from '../../../src/controllers/access/access.js';
 import * as AccessServices from '../../../src/models/services/access.js';
+import * as Models from '../../../src/models/index.js';
 import { Request, Response } from 'express';
 import ExpressError from '../../../src/utils/ExpressError.js';
 
@@ -14,12 +15,19 @@ jest.mock('../../../src/utils/ExpressError.js');
 // Consolidated mock for services
 jest.mock('../../../src/models/services/access.js', () => ({
   updateJournalTitle: jest.fn(),
+  getAccount: jest.fn(),
+  updateProfile: jest.fn(),
+  updatePassword: jest.fn(),
+  updateConfig: jest.fn(),
+  deleteConfig: jest.fn(),
+  deleteAccount: jest.fn(),
 }));
 
 const mockReq = () => {
   const flashStore: { [key: string]: string[] } = {};
   const req = {} as Partial<Request>;
   req.params = {};
+  req.query = {};
   req.body = {};
   req.flash = jest.fn((errorType?: string, message?: string) => {
     if (errorType && message) flashStore[errorType] = [message];
@@ -102,6 +110,299 @@ describe('Entry Controller Tests', () => {
 
       await AccessController.updateJournal(req, res, next);
 
+      expect(next).toHaveBeenCalledWith(expect.any(ExpressError));
+    });
+  });
+
+  describe('getAccount', () => {
+    it('should return the account with config and user documents', async () => {
+      const req = mockReq();
+      req.params.journalId = 'testJournalId';
+    
+      const res = mockRes();
+      const next = mockNext();
+    
+      (AccessServices.getAccount as jest.Mock).mockResolvedValue({
+        configMessage: null,
+        user: { _id: 'testUserId', name: 'Test User' },
+        config: { _id: 'testConfigId', settings: {} },
+      });
+    
+      await AccessController.getAccount(req, res, next);
+    
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        user: { _id: 'testUserId', name: 'Test User' },
+        config: { _id: 'testConfigId', settings: {} },
+        flash: {},
+      });
+    });
+
+    it('should return an info flash message if configMessage is not null', async () => {
+      const req = mockReq();
+      req.params.journalId = 'testJournalId';
+    
+      const res = mockRes();
+      const next = mockNext();
+    
+      (AccessServices.getAccount as jest.Mock).mockResolvedValue({
+        configMessage: 'Test config message',
+        user: { _id: 'testUserId', name: 'Test User' },
+        config: { _id: 'testConfigId', settings: {} },
+      });
+    
+      await AccessController.getAccount(req, res, next);
+    
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        user: { _id: 'testUserId', name: 'Test User' },
+        config: { _id: 'testConfigId', settings: {} },
+        flash: { info: ['Test config message'] },
+      });
+    });
+
+    it('should call next with an error if an error is thrown', async () => {
+      const req = mockReq();
+      req.params.accountId = 'testAccountId';
+
+      const res = mockRes();
+      const next = mockNext();
+
+      (AccessServices.getAccount as jest.Mock).mockRejectedValueOnce(new Error('Test error'));
+
+      await AccessController.getAccount(req, res, next);
+
+      expect(next).toHaveBeenCalledWith(expect.any(ExpressError));
+    });
+  });
+
+  describe('updateAccount', () => {
+    let req: ReturnType<typeof mockReq>;
+    let res: ReturnType<typeof mockRes>;
+    let next: jest.Mock;
+  
+    beforeEach(() => {
+      jest.clearAllMocks();
+      req = mockReq();
+      res = mockRes();
+      next = mockNext();
+    });
+  
+    it('should update the password successfully', async () => {
+      req.params.journalId = 'testJournalId';
+      req.body.password = { oldPassword: 'oldPass', newPassword: 'newPass' };
+  
+      const journalMock = { _id: 'testJournalId', user: 'testUserId' };
+      (Models.Journal.findById as jest.Mock).mockResolvedValueOnce(journalMock);
+      (AccessServices.updatePassword as jest.Mock).mockResolvedValueOnce(undefined);
+  
+      await AccessController.updateAccount(req, res, next);
+  
+      expect(AccessServices.updatePassword).toHaveBeenCalledWith('testUserId', 'oldPass', 'newPass');
+      expect(req.flash).toHaveBeenCalledWith('success', 'Password updated successfully.');
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({ flash: { 
+        info: ['Please log in again with your new credentials.'], 
+        success: ['Password updated successfully.'] } });
+    });
+
+    it('should call next with an error if updatePassword throws an error', async () => {
+      req.params.journalId = 'testJournalId';
+      req.body.password = { oldPassword: 'oldPass', newPassword: 'newPass' };
+  
+      const journalMock = { _id: 'testJournalId', user: 'testUserId' };
+      (Models.Journal.findById as jest.Mock).mockResolvedValueOnce(journalMock);
+      (AccessServices.updatePassword as jest.Mock).mockRejectedValueOnce(new Error('Test error'));
+  
+      await AccessController.updateAccount(req, res, next);
+  
+      expect(next).toHaveBeenCalledWith(expect.any(Error));
+    });
+
+    it('should update the config successfully', async () => {
+      req.params.journalId = 'testJournalId';
+      req.body.config = { model: { chat: 'testChatModel', analysis: 'testAnalysisModel' } };
+  
+      const journalMock = { _id: 'testJournalId', user: 'testUserId', config: 'configId' };
+      (Models.Journal.findById as jest.Mock).mockResolvedValueOnce(journalMock);
+      (AccessServices.updateConfig as jest.Mock).mockResolvedValueOnce(undefined);
+  
+      await AccessController.updateAccount(req, res, next);
+  
+      expect(AccessServices.updateConfig).toHaveBeenCalledWith('configId', journalMock, {  model: { chat: 'testChatModel', analysis: 'testAnalysisModel' } });
+      expect(req.flash).toHaveBeenCalledWith('success', 'Config updated successfully.');
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({ flash: { success: ['Config updated successfully.'] } });
+    });
+
+    it('should update the profile successfully', async () => {
+      req.params.journalId = 'testJournalId';
+      req.body.profile = { fname: 'New', lname: 'Name' };
+  
+      const journalMock = { _id: 'testJournalId', user: 'testUserId' };
+      (Models.Journal.findById as jest.Mock).mockResolvedValueOnce(journalMock);
+      (AccessServices.updateProfile as jest.Mock).mockResolvedValueOnce({
+        user: { _id: 'testUserId' },
+        errorMessage: undefined,
+      });
+  
+      await AccessController.updateAccount(req, res, next);
+  
+      expect(Models.Journal.findById).toHaveBeenCalledWith('testJournalId');
+      expect(AccessServices.updateProfile).toHaveBeenCalledWith('testUserId', { fname: 'New', lname: 'Name' });
+      expect(req.flash).toHaveBeenCalledWith('success', 'Profile updated successfully.');
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({ flash: { success: ['Profile updated successfully.'] } });
+    });
+
+    it('should handle an error when updating the profile fails', async () => {
+      req.params.journalId = 'testJournalId';
+      req.body.profile = { fname: 'Test', lname: 'User' };
+  
+      const journalMock = { _id: 'testJournalId', user: 'testUserId' };
+      (Models.Journal.findById as jest.Mock).mockResolvedValueOnce(journalMock);
+      (AccessServices.updateProfile as jest.Mock).mockResolvedValueOnce({
+        user: 'testUserId',
+        errorMessage: 'Invalid email address.',
+      });
+  
+      await AccessController.updateAccount(req, res, next);
+  
+      expect(req.flash).toHaveBeenCalledWith('warning', 'The email address provided cannot be used.');
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({ flash: { 
+        success: ['Profile updated successfully.'],
+        warning: ['The email address provided cannot be used.'] } });
+    });
+  
+    it('should call next with an ExpressError if journal is not found', async () => {
+      req.params.journalId = 'nonexistentJournalId';
+      req.body.profile = { fname: 'Test', lname: 'User' };
+  
+      (Models.Journal.findById as jest.Mock).mockResolvedValueOnce(null);
+  
+      await AccessController.updateAccount(req, res, next);
+  
+      expect(next).toHaveBeenCalledWith(expect.any(ExpressError));
+    });
+
+    it('should call next with an ExpressError if an user is not found', async () => {
+      req.params.journalId = 'testJournalId';
+      req.body.profile = { fname: 'Test', lname: 'User' };
+  
+      const journalMock = { _id: 'testJournalId', user: 'testUserId' };
+      (Models.Journal.findById as jest.Mock).mockResolvedValueOnce(journalMock);
+      (AccessServices.updateProfile as jest.Mock).mockResolvedValueOnce({
+        user: null,
+        errorMessage: undefined,
+      });
+
+      await AccessController.updateAccount(req, res, next);
+
+      expect(next).toHaveBeenCalledWith(expect.any(ExpressError));
+    });
+  
+    it('should handle unexpected errors gracefully', async () => {
+      req.params.journalId = 'testJournalId';
+      req.body.profile = { fname: 'Test', lname: 'User' };
+  
+      const unexpectedError = new Error('Unexpected error');
+      (Models.Journal.findById as jest.Mock).mockRejectedValueOnce(unexpectedError);
+  
+      await AccessController.updateAccount(req, res, next);
+  
+      expect(next).toHaveBeenCalledWith(expect.any(ExpressError));
+    });
+  });
+
+  describe('deleteItem', () => {
+    it('should return a success flash message if the config is deleted', async () => {
+      const req = mockReq();
+      req.params.journalId = 'testJournalId';
+      req.query.deletionItem = 'config';
+    
+      const res = mockRes();
+      const next = mockNext();
+    
+      (AccessServices.deleteConfig as jest.Mock).mockResolvedValue(true);
+    
+      await AccessController.deleteItem(req, res, next);
+    
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({ flash: { success: ['Config deleted successfully.'] } });
+    });
+
+    it('should call next if an error if thrown by deleteConfig', async () => {
+      const req = mockReq();
+      req.params.journalId = 'testJournalId';
+      req.query.deletionItem = 'config';
+    
+      const res = mockRes();
+      const next = mockNext();
+    
+      (AccessServices.deleteConfig as jest.Mock).mockRejectedValueOnce(new Error('Test error'));
+    
+      await AccessController.deleteItem(req, res, next);
+    
+      expect(next).toHaveBeenCalledWith(expect.any(Error));
+    });
+
+    it('should return a success flash message if the account is deleted', async () => {
+      const req = mockReq();
+      req.params.journalId = 'testJournalId';
+      req.query.deletionItem = 'account';
+    
+      const res = mockRes();
+      const next = mockNext();
+    
+      (AccessServices.deleteAccount as jest.Mock).mockResolvedValue(true);
+    
+      await AccessController.deleteItem(req, res, next);
+    
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({ flash: { success: ['Account deleted successfully.'] } });
+    });
+
+    it('should call next with an ExpressError defined by deleteAccount', async () => {
+      const req = mockReq();
+      req.params.journalId = 'testJournalId';
+      req.query.deletionItem = 'account';
+    
+      const res = mockRes();
+      const next = mockNext();
+    
+      (AccessServices.deleteAccount as jest.Mock).mockRejectedValueOnce(new ExpressError('Test error', 400));
+    
+      await AccessController.deleteItem(req, res, next);
+    
+      expect(next).toHaveBeenCalledWith(expect.any(ExpressError));
+    });
+
+    it('should call next with an error defined in deleteItem if a non-ExpressError is thrown', async () => {
+      const req = mockReq();
+      req.params.journalId = 'testJournalId';
+      req.query.deletionItem = 'account';
+    
+      const res = mockRes();
+      const next = mockNext();
+    
+      (AccessServices.deleteAccount as jest.Mock).mockRejectedValueOnce(new Error('Test error'));
+    
+      await AccessController.deleteItem(req, res, next);
+    
+      expect(next).toHaveBeenCalledWith(expect.any(ExpressError));
+    });
+
+    it('should call next with an ExpressError if an invalid deletionItem is provided', async () => {
+      const req = mockReq();
+      req.params.journalId = 'testJournalId';
+      req.query.deletionItem = 'invalidItem';
+    
+      const res = mockRes();
+      const next = mockNext();
+    
+      await AccessController.deleteItem(req, res, next);
+    
       expect(next).toHaveBeenCalledWith(expect.any(ExpressError));
     });
   });

--- a/backend/tests/controllers/access/access.test.ts
+++ b/backend/tests/controllers/access/access.test.ts
@@ -39,6 +39,8 @@ jest.mock('../../../src/models/services/access.js', () => ({
   deleteAccount: jest.fn(),
   ensureJournalExists: jest.fn(),
   getPopulatedJournal: jest.fn(),
+  forgotPassword: jest.fn(),
+  resetPassword: jest.fn(),
 }));
 
 const mockReq = () => {
@@ -793,6 +795,82 @@ describe('Entry Controller Tests', () => {
       await AccessController.tokenLogin(req, res, next);
   
       expect(next).toHaveBeenCalledWith(expect.any(Error));
+    });
+  });
+
+  describe('forgotPassword', () => {
+    it('should return a success flash message if the email is found', async () => {
+      const req = mockReq();
+      req.body = { email: 'test@test.com' };
+
+      const res = mockRes();
+      const next = mockNext();
+
+      (AccessServices.forgotPassword as jest.Mock).mockResolvedValueOnce(undefined);
+
+      await AccessController.forgotPassword(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({ flash: { success: ['Recovery email sent successfully.'] } });
+    });
+
+    it('should call next with an error if an error is thrown', async () => {
+      const req = mockReq();
+      req.body = { email: 'test@test.com' };
+
+      const res = mockRes();
+      const next = mockNext();
+
+      (AccessServices.forgotPassword as jest.Mock).mockRejectedValueOnce(new Error('Test error'));
+
+      await AccessController.forgotPassword(req, res, next);
+
+      expect(next).toHaveBeenCalledWith(expect.any(Error));
+    });
+  });
+
+  describe('resetPassword', () => {
+    it('should return a success flash message if the password is reset', async () => {
+      const req = mockReq();
+      req.body = { password: 'newPass', token: 'testToken' };
+
+      const res = mockRes();
+      const next = mockNext();
+
+      (AccessServices.resetPassword as jest.Mock).mockResolvedValueOnce(undefined);
+
+      await AccessController.resetPassword(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({ flash: { success: ['Password reset successfully.'] } });
+    });
+
+    it('should call next with an ExpressError if an ExpressError is thrown', async () => {
+      const req = mockReq();
+      req.body = { password: 'newPass', token: 'testToken' };
+
+      const res = mockRes();
+      const next = mockNext();
+
+      (AccessServices.resetPassword as jest.Mock).mockRejectedValueOnce(new ExpressError('Test error', 400));
+
+      await AccessController.resetPassword(req, res, next);
+
+      expect(next).toHaveBeenCalledWith(expect.any(ExpressError));
+    });
+
+    it('should call next with an ExpressError if an Error is thrown', async () => {
+      const req = mockReq();
+      req.body = { password: 'newPass', token: 'testToken' };
+
+      const res = mockRes();
+      const next = mockNext();
+
+      (AccessServices.resetPassword as jest.Mock).mockRejectedValueOnce(new Error('Test error'));
+
+      await AccessController.resetPassword(req, res, next);
+
+      expect(next).toHaveBeenCalledWith(expect.any(ExpressError));
     });
   });
 });

--- a/backend/tests/controllers/access/access.test.ts
+++ b/backend/tests/controllers/access/access.test.ts
@@ -1,0 +1,108 @@
+import * as AccessController from '../../../src/controllers/access/access.js';
+import * as AccessServices from '../../../src/models/services/access.js';
+import { Request, Response } from 'express';
+import ExpressError from '../../../src/utils/ExpressError.js';
+
+jest.mock('../../../src/models/index.js', () => ({
+  Journal: {
+    findById: jest.fn(),
+  },
+}));
+
+jest.mock('../../../src/utils/ExpressError.js');
+
+// Consolidated mock for services
+jest.mock('../../../src/models/services/access.js', () => ({
+  updateJournalTitle: jest.fn(),
+}));
+
+const mockReq = () => {
+  const flashStore: { [key: string]: string[] } = {};
+  const req = {} as Partial<Request>;
+  req.params = {};
+  req.body = {};
+  req.flash = jest.fn((errorType?: string, message?: string) => {
+    if (errorType && message) flashStore[errorType] = [message];
+    return flashStore;
+  }) as never;
+  return req as Request;
+};
+
+const mockRes = () => {
+  const res = {} as Partial<Response>;
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res as Response;
+};
+
+const mockNext = (): jest.Mock => jest.fn();
+
+describe('Entry Controller Tests', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('updateJournal', () => {
+    it('should return a success flash message if the journal title is updated', async () => {
+      const req = mockReq();
+      req.params.journalId = 'testJournalId';
+      req.body.title = 'testTitle';
+
+      const res = mockRes();
+      const next = mockNext();
+
+      (AccessServices.updateJournalTitle as jest.Mock).mockResolvedValueOnce(true);
+
+      await AccessController.updateJournal(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({ flash: { success: ['Journal title updated successfully.'] } });
+    });
+
+    it('should return an error flash message if the journal title is not updated', async () => {
+      const req = mockReq();
+      req.params.journalId = 'testJournalId';
+      req.body.title = 'testTitle';
+
+      const res = mockRes();
+      const next = mockNext();
+
+      (AccessServices.updateJournalTitle as jest.Mock).mockResolvedValueOnce(false);
+
+      await AccessController.updateJournal(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({ 'flash': { 'warning': ['Journal title not updated.'] } });
+    });
+
+    it('should call next with an error if an error is thrown', async () => {
+      const req = mockReq();
+      req.params.journalId = 'testJournalId';
+      req.body.title = 'testTitle';
+
+      const res = mockRes();
+      const next = mockNext();
+
+      (AccessServices.updateJournalTitle as jest.Mock).mockRejectedValueOnce(new Error('Test error'));
+
+      await AccessController.updateJournal(req, res, next);
+
+      expect(next).toHaveBeenCalledWith(expect.any(ExpressError));
+    });
+
+    it('should return an error if an ExpressError is thrown', async () => {
+      const req = mockReq();
+      req.params.journalId = 'testJournalId';
+      req.body.title = 'testTitle';
+
+      const res = mockRes();
+      const next = mockNext();
+
+      (AccessServices.updateJournalTitle as jest.Mock).mockRejectedValueOnce(new ExpressError('Test error', 400));
+
+      await AccessController.updateJournal(req, res, next);
+
+      expect(next).toHaveBeenCalledWith(expect.any(ExpressError));
+    });
+  });
+});

--- a/backend/tests/controllers/access/access.test.ts
+++ b/backend/tests/controllers/access/access.test.ts
@@ -60,6 +60,7 @@ const mockReq = () => {
       return callback(null);
     }
   }) as jest.Mock;
+  req.logout = jest.fn();
   return req as Request;
 };
 
@@ -871,6 +872,34 @@ describe('Entry Controller Tests', () => {
       await AccessController.resetPassword(req, res, next);
 
       expect(next).toHaveBeenCalledWith(expect.any(ExpressError));
+    });
+  });
+
+  describe('logout', () => {
+    it('should return a success flash message if the user is logged out', async () => {
+      const req = mockReq();
+      const res = mockRes();
+      const next = mockNext();
+
+      AccessController.logout(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({ 
+        flash: { success: ['Logged out successfully.'] },
+        'message': 'Logged out successfully.',
+      });
+    });
+
+    it('should call next with an error if logout fails', () => {
+      const req = mockReq();
+      const res = mockRes();
+      const next = mockNext();
+    
+      req.logout = jest.fn((callback) => callback(new Error('Logout failed'))) as never;
+    
+      AccessController.logout(req, res, next);
+    
+      expect(next).toHaveBeenCalledWith(new Error('Logout failed'));
     });
   });
 });

--- a/backend/tests/controllers/access/access.test.ts
+++ b/backend/tests/controllers/access/access.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 import * as AccessController from '../../../src/controllers/access/access.js';
-import * as AccessServices from '../../../src/models/services/access.js';
+import * as AccessServices from '../../../src/models/services/access/access.js';
 import * as Models from '../../../src/models/index.js';
 import { Request, Response } from 'express';
 import ExpressError from '../../../src/utils/ExpressError.js';
@@ -29,7 +29,7 @@ jest.mock('passport', () => ({
 }));
 
 // Consolidated mock for services
-jest.mock('../../../src/models/services/access.js', () => ({
+jest.mock('../../../src/models/services/access/access.js', () => ({
   updateJournalTitle: jest.fn(),
   getAccount: jest.fn(),
   updateProfile: jest.fn(),

--- a/backend/tests/controllers/access/access.test.ts
+++ b/backend/tests/controllers/access/access.test.ts
@@ -38,6 +38,7 @@ jest.mock('../../../src/models/services/access.js', () => ({
   deleteConfig: jest.fn(),
   deleteAccount: jest.fn(),
   ensureJournalExists: jest.fn(),
+  getPopulatedJournal: jest.fn(),
 }));
 
 const mockReq = () => {
@@ -622,6 +623,176 @@ describe('Entry Controller Tests', () => {
 
       expect(next).toHaveBeenCalledWith(expect.any(ExpressError));
       expect(res.status).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('tokenLogin', () => {
+    const ORIGINAL_RELEASE_PHASE = process.env.RELEASE_PHASE;
+
+    beforeAll(() => {
+      process.env.RELEASE_PHASE = '';
+    });
+  
+    afterAll(() => {
+      process.env.RELEASE_PHASE = ORIGINAL_RELEASE_PHASE;
+    });
+  
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+  
+    it('should call next with a 403 error if token is invalid or has expired', async () => {
+      const req = mockReq();
+      req.token = undefined;
+
+      const res = mockRes();
+      const next = mockNext();
+  
+      // No token on req => triggers the 403 path
+      await AccessController.tokenLogin(req, res, next);
+  
+      expect(next).toHaveBeenCalledWith(expect.any(ExpressError));
+      expect(res.status).not.toHaveBeenCalled();
+    });
+  
+    it('should call next with a 404 error if journal is not found', async () => {
+      const req = mockReq();
+      req.token = 'testTokenId';
+
+      const res = mockRes();
+      const next = mockNext();
+  
+      (AccessServices.getPopulatedJournal as jest.Mock).mockResolvedValueOnce(null);
+  
+      await AccessController.tokenLogin(req, res, next);
+  
+      expect(next).toHaveBeenCalledWith(expect.any(ExpressError));
+    });
+  
+    it('should call next with an error if req.logIn fails', async () => {
+      const req = mockReq();
+      req.token = 'testTokenId';
+
+      const res = mockRes();
+      const next = mockNext();
+  
+      (AccessServices.getPopulatedJournal as jest.Mock).mockResolvedValueOnce({
+        _id: 'testJournalId',
+        title: 'testJournalTitle',
+      });
+  
+      // Force req.logIn to fail
+      req.logIn = jest.fn((user, cb) => cb(new Error('logIn failed'))) as never;
+  
+      await AccessController.tokenLogin(req, res, next);
+  
+      expect(next).toHaveBeenCalledWith(new Error('logIn failed'));
+      expect(res.status).not.toHaveBeenCalled();
+    });
+  
+    it('should flash info if token is within 12 hours old', async () => {
+      // `iat` is 1 hour ago => within 12 hours
+      const req = mockReq();
+      req.token = { id: 'testUserId', iat: Math.floor(Date.now() / 1000) - 3600 };
+
+      const res = mockRes();
+      const next = mockNext();
+  
+      const userMock = { fname: 'Test' };
+      (AccessServices.getPopulatedJournal as jest.Mock).mockResolvedValueOnce({
+        _id: 'testJournalId',
+        title: 'testJournalTitle',
+        user: userMock,
+      });
+  
+      await AccessController.tokenLogin(req, res, next);
+  
+      expect(req.flash).toHaveBeenCalledWith('info', 'Logging out will prevent automatic future logins.');
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        journalId: 'testJournalId',
+        journalTitle: 'testJournalTitle',
+        flash: {
+          success: ['Welcome back, Test. You\'ve been automatically logged in successfully.'],
+          info: ['Logging out will prevent automatic future logins.'],
+        },
+      });
+      expect(next).not.toHaveBeenCalled();
+    });
+  
+    it('should not return info flash if token is older than 12 hours', async () => {
+      // `iat` is 24 hours ago => outside 12 hour window
+      const req = mockReq();
+      req.token = { id: 'testUserId', iat: Math.floor(Date.now() / 1000) - 86400 };
+
+      const res = mockRes();
+      const next = mockNext();
+  
+      const userMock = { fname: 'Test' };
+      (AccessServices.getPopulatedJournal as jest.Mock).mockResolvedValueOnce({
+        _id: 'testJournalId',
+        title: 'testJournalTitle',
+        user: userMock,
+      });
+  
+      await AccessController.tokenLogin(req, res, next);
+  
+      expect(req.flash).toHaveBeenCalledWith(
+        'success',
+        'Welcome back, Test. You\'ve been automatically logged in successfully.'
+      );
+  
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        journalId: 'testJournalId',
+        journalTitle: 'testJournalTitle',
+        flash: {
+          success: ['Welcome back, Test. You\'ve been automatically logged in successfully.'],
+        },
+      });
+      expect(next).not.toHaveBeenCalled();
+    });
+  
+    it('should return 200 if token is valid and login is successful', async () => {  
+      const req = mockReq();
+      req.token = { id: 'testUserId', iat: Math.floor(Date.now() / 1000) - 3600 };
+
+      const res = mockRes();
+      const next = mockNext();
+  
+      const userMock = { fname: 'Test', betaAccess: false, save: jest.fn() };
+      (AccessServices.getPopulatedJournal as jest.Mock).mockResolvedValueOnce({
+        _id: 'testJournalId',
+        title: 'testJournalTitle',
+        user: userMock,
+      });
+  
+      await AccessController.tokenLogin(req, res, next);
+  
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        journalId: 'testJournalId',
+        journalTitle: 'testJournalTitle',
+        flash: {
+          info: ['Logging out will prevent automatic future logins.'],
+          success: ['Welcome back, Test. You\'ve been automatically logged in successfully.'],
+        },
+      });
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('should call next with an error if an unexpected error occurs', async () => {
+      const req = mockReq();
+      req.token = { id: 'testUserId', iat: Math.floor(Date.now() / 1000) - 3600 };
+
+      const res = mockRes();
+      const next = mockNext();
+  
+      (AccessServices.getPopulatedJournal as jest.Mock).mockRejectedValueOnce(new Error('Test error'));
+  
+      await AccessController.tokenLogin(req, res, next);
+  
+      expect(next).toHaveBeenCalledWith(expect.any(Error));
     });
   });
 });

--- a/backend/tests/models/services/access/access.test.ts
+++ b/backend/tests/models/services/access/access.test.ts
@@ -2,14 +2,14 @@
  * @jest-environment node
  */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import * as AccessServices from '../../../src/models/services/access.js';
-import { Config, Entry, Journal, User } from '../../../src/models/index.js';
+import * as AccessServices from '../../../../src/models/services/access/access.js';
+import { Config, Entry, Journal, User } from '../../../../src/models/index.js';
 import mongoose, { HydratedDocument } from 'mongoose';
-import { ConfigType } from '../../../src/models/config.js';
-import ExpressError from '../../../src/utils/ExpressError.js';
-import { JournalType } from '../../../src/models/journal.js';
-import { UserType } from '../../../src/models/user.js';
-import connectDB from '../../../src/db.js';
+import { ConfigType } from '../../../../src/models/config.js';
+import ExpressError from '../../../../src/utils/ExpressError.js';
+import { JournalType } from '../../../../src/models/journal.js';
+import { UserType } from '../../../../src/models/user.js';
+import connectDB from '../../../../src/db.js';
 
 describe('Account services tests', () => {
   let testUser: UserType;


### PR DESCRIPTION
This PR adds access controller unit tests. The initial commit does the following,

- Add mocks.
  - Mock `Journal.findById`.
  - Mock `ExpressError`.
  - Mock all access services.
  - Mock `Request`, `Response`, and, `next`.
- Create Entry Controller Tests test suite.
- Clear mocks before each test sub-suite.
- Add `updateJournal` test suite.